### PR TITLE
Ask for discarding unsaved changes

### DIFF
--- a/static/scripts/main.js
+++ b/static/scripts/main.js
@@ -129,8 +129,8 @@ CHANGE_OPERATIONS = [
 function setHasUnsavedChanges(event) {
   if (CHANGE_OPERATIONS.includes(event.type)) {
     hasUnsavedChanges = true;
-    console.warn("Workspace has unsaved changes now");
     workspace.removeChangeListener(setHasUnsavedChanges);
+    console.warn("Workspace has unsaved changes now");
   }
 }
 
@@ -142,7 +142,7 @@ function resetHasUnsavedChanges() {
 
 function waitForFinishedLoading(event) {
   if (event.type == Blockly.Events.FINISHED_LOADING) {
-    workspace.addChangeListener(setHasUnsavedChanges);
+    resetHasUnsavedChanges()
     workspace.removeChangeListener(waitForFinishedLoading);
   }
 }

--- a/static/scripts/main.js
+++ b/static/scripts/main.js
@@ -31,6 +31,12 @@ function replaceWorkspaceQuestion(xml) {
     replaceWorkspaceWithXml(xml);
 }
 
+window.addEventListener("beforeunload", function(e){
+  if(hasUnsavedChanges){
+    e.preventDefault()
+  }
+})
+
 function replaceWorkspaceWithXml(xml) {
   if(hasUnsavedChanges){
     if(!window.confirm("Do you want discard your changes?"))

--- a/static/scripts/main.js
+++ b/static/scripts/main.js
@@ -32,7 +32,7 @@ function replaceWorkspaceQuestion(xml) {
 
 function replaceWorkspaceWithXml(xml) {
   if(HAS_UNSAVED_CHANGES){
-    if(!window.confirm("Do you want discard your changes?"))
+    if(!window.confirm("Are you sure you want to exit without saving?"))
       return
   }
   workspace.clear();
@@ -136,7 +136,7 @@ function unsavedChangesListener(event) {
 
 function beforeUnloadListener(e){
   e.preventDefault();
-  return e.returnValue = "Are you sure you want to exit?";
+  return e.returnValue = "Are you sure you want to exit without saving?";
 }
 
 function resetHasUnsavedChanges() {

--- a/static/scripts/main.js
+++ b/static/scripts/main.js
@@ -1,7 +1,6 @@
 USING_THREADS = false;
 PREV_DEFINITIONS = null;
-
-let hasUnsavedChanges = false
+HAS_UNSAVED_CHANGES = false;
 
 const copyToClipboard = str => {
     const el = document.createElement('textarea');
@@ -31,14 +30,8 @@ function replaceWorkspaceQuestion(xml) {
     replaceWorkspaceWithXml(xml);
 }
 
-window.addEventListener("beforeunload", function(e){
-  if(hasUnsavedChanges){
-    e.preventDefault()
-  }
-})
-
 function replaceWorkspaceWithXml(xml) {
-  if(hasUnsavedChanges){
+  if(HAS_UNSAVED_CHANGES){
     if(!window.confirm("Do you want discard your changes?"))
       return
   }
@@ -132,18 +125,25 @@ CHANGE_OPERATIONS = [
   Blockly.Events.COMMENT_CHANGE,
   Blockly.Events.COMMENT_MOVE,
 ];
-function setHasUnsavedChanges(event) {
+function unsavedChangesListener(event) {
   if (CHANGE_OPERATIONS.includes(event.type)) {
-    hasUnsavedChanges = true;
-    workspace.removeChangeListener(setHasUnsavedChanges);
+    HAS_UNSAVED_CHANGES = true
+    workspace.removeChangeListener(unsavedChangesListener)
+    window.addEventListener("beforeunload", beforeUnloadListener)
     console.warn("Workspace has unsaved changes now");
   }
 }
 
+function beforeUnloadListener(e){
+  e.preventDefault();
+  return e.returnValue = "Are you sure you want to exit?";
+}
+
 function resetHasUnsavedChanges() {
-  hasUnsavedChanges = false;
-  workspace.addChangeListener(setHasUnsavedChanges);
-  console.warn("Workspace has no unsaved changes now");
+  HAS_UNSAVED_CHANGES = false
+  workspace.addChangeListener(unsavedChangesListener)
+  window.removeEventListener("beforeunload", beforeUnloadListener)
+  console.warn("Workspace has no unsaved changes now")
 }
 
 function waitForFinishedLoading(event) {


### PR DESCRIPTION
I've added a confirmation popup if the user wants to discard unsaved changes.
It uses a global boolean variable `hasUnsavedChanges` which is set when an event from the list `CHANGE_OPERATIONS` is fired.

The associated Eventlistener is added when the user downloads or loads a workspace. But whenever a workspace is loaded same events are fired as if the user would do them. That's why I've added `waitForFinishedLoading` between loading a workspace and resetting `hasUnsavedChanges`.