### PR TITLE
Fix missing resetUnsavedChanges when copying to clipboard

### DIFF
--- a/static/scripts/main.js
+++ b/static/scripts/main.js
@@ -50,11 +50,13 @@ function promptForXML() {
 function copyXMLToClipboard() {
   var xml = Blockly.Xml.domToPrettyText(Blockly.Xml.workspaceToDom(workspace));
   copyToClipboard(xml)
+  resetHasUnsavedChanges()
 }
 
 function copyJSToClipboard() {
   var js = getCode();
   copyToClipboard(js);
+  resetHasUnsavedChanges()
 }
 
 function showXMLInPopup() {


### PR DESCRIPTION
Currently, when copying to the clipboard it doesn't reset the unsavedChanges-functionality. It isn't recognized as saving changes. This PR fixes it.