### PR TITLE
Make comment blocks multiline

### DIFF
--- a/static/scripts/newblocks.js
+++ b/static/scripts/newblocks.js
@@ -589,7 +589,7 @@ Blockly.defineBlocksWithJsonArray([
     message0: '// "%1"',
     args0: [
       {
-        type: "field_input",
+        type: "field_multilinetext",
         name: "text",
         text: "Add comment",
       },
@@ -666,7 +666,7 @@ Blockly.JavaScript["experimental_raw_value"] = function (block) {
 };
 
 Blockly.JavaScript["comment"] = function (block) {
-  return "//" + block.getFieldValue("text") + "\n";
+  return "//" + block.getFieldValue("text").replaceAll('\n',' ') + "\n";
 };
 
 Blockly.JavaScript["experimental_timer"] = function (block) {


### PR DESCRIPTION
I couldn't find a way to make the comment blocks wider, so I allowed multiple lines instead. I am sure there are ways to make the use of these comment blocks better, but they do their job right now, so this is something that can be revised later. What do you think @antonykamp ? 