### PR TITLE
Remove URL query after upload

### DIFF
--- a/static/scripts/modules/exampleHandling.js
+++ b/static/scripts/modules/exampleHandling.js
@@ -61,4 +61,4 @@ window.onpopstate = function () {
 update_parameters();
 load_example_from_url();
 
-export { loadExample };
+export { loadExample, update_url, PARAMETERS };

--- a/static/scripts/modules/import.js
+++ b/static/scripts/modules/import.js
@@ -4,11 +4,14 @@ import {
   HAS_UNSAVED_CHANGES,
   setupUnsavedChangesHandling,
 } from "./unsavedChangesHandling";
+import { PARAMETERS, update_url } from "./exampleHandling";
 
 function replaceWorkspaceQuestion(xml) {
   if(!replaceWorkspaceWithXml(xml))
     return;
   document.getElementById("workspace-title").innerHTML = "Untitled";
+  PARAMETERS.delete('example');
+  update_url();
 }
 
 function replaceWorkspaceWithXml(xml) {

--- a/static/scripts/modules/import.js
+++ b/static/scripts/modules/import.js
@@ -7,10 +7,9 @@ import {
 import { PARAMETERS, update_url } from "./exampleHandling";
 
 function replaceWorkspaceQuestion(xml) {
-  if(!replaceWorkspaceWithXml(xml))
-    return;
+  if (!replaceWorkspaceWithXml(xml)) return;
   document.getElementById("workspace-title").innerHTML = "Untitled";
-  PARAMETERS.delete('example');
+  PARAMETERS.delete("example");
   update_url();
 }
 


### PR DESCRIPTION
It removes the Query `example?` from the URL, after loading a custom workspace.