### PR TITLE
Forward error to user

### DIFF
--- a/static/scripts/MessageHandler.js
+++ b/static/scripts/MessageHandler.js
@@ -207,6 +207,13 @@ function consoleLog(...v) {
   consolelog(v);
 }
 
+//eslint-disable-next-line no-unused-vars -- is used in code blockly compiles
+function consoleerror(e){
+  consolelog(e)
+  consolelog('Find more information in the console.')
+  console.error(e)
+}
+
 // creates the message handler object for the calling script to use
 var Handler = new MessageHandler();
 

--- a/static/scripts/newblocks.js
+++ b/static/scripts/newblocks.js
@@ -725,10 +725,14 @@ Blockly.JavaScript["ea_init"] = function (block) {
 
   let code = "";
   code = "function* main() {\n\n";
+  code += "try {\n";
   code += statements_simulation_steps;
-  code += "\n";
+  code += "} catch(e) {\n";
+  code += "    consoleerror(e);\n"
+  code += "} finally {\n"
   code +=
-    '  Handler.sendMessage(new Message(Handler.PARENT_ID, 0, "terminate"));\n';
+  '  Handler.sendMessage(new Message(Handler.PARENT_ID, 0, "terminate"));\n';
+  code += "};\n"
   code += "}\n";
   code += "var main = main();\n";
   code += "main.next();\n";

--- a/static/scripts/threadblocks.js
+++ b/static/scripts/threadblocks.js
@@ -219,6 +219,7 @@ function generate_worker_code(statements, return_val) {
   PREV_DEFINITIONS = definitions;
 
   worker_code += "function* main() {\n";
+  worker_code += "try {\n";
 
   // execute the internal statements and return the value
   worker_code += "`+`" + escape_string(statements) + "`+`;\n";
@@ -226,6 +227,9 @@ function generate_worker_code(statements, return_val) {
     "  Handler.sendMessage(new Message(Handler.PARENT_ID, " +
     return_val +
     "));\n";
+  worker_code += "} catch (e) {\n";
+  worker_code += "    consoleerror(e);\n"
+  worker_code += "}\n"
   worker_code += "}\n";
   // the message handler will automatically run main.next() when the THREAD_ID is received
   worker_code += "var main = main();\n";


### PR DESCRIPTION
It forwards errors to the user by adding a new function `consoleerror` to the MessageHandler. It uses the same pattern as `consolelog` except to print the error to the full error to the console, too.