### PR TITLE
Collapse navbar after clicking on dropdown-item

### DIFF
--- a/static/scripts/workspace.js
+++ b/static/scripts/workspace.js
@@ -38,7 +38,7 @@ $("#example-multithread-performance").click(() =>
   loadExample("multithread-performance")
 );
 
-$("#upload_xml").click(() => $("#upload_xml_input").click())
+$("#upload_xml").click(() => $("#upload_xml_input").click());
 $("#upload_xml_input").change(selectedFileChanged);
 $("#promt_for_xml").click(promptForXML);
 $("#download_xml").click(downloadWorkspace);
@@ -47,3 +47,7 @@ $("#download_js").click(downloadWorkspaceAsJS);
 $("#copy_js").click(copyJSToClipboard);
 $("#show_js").click(highlightAll);
 $("#download_json").click(downloadLog);
+
+$(".dropdown-menu>a").on("click", function () {
+  $(".navbar-collapse").removeClass("show");
+});


### PR DESCRIPTION
Now the navbar collapses after clicking on a dropdown-item, which has a direct impact on the current side. These are items like loading an example or importing an XML script.

Should we add this functionality. If yes, should we add it to drop-down item without impact on the current side (like showing plots or FAQ)?