### PR TITLE
Add loading icon to documentation

### DIFF
--- a/static/css/globals.css
+++ b/static/css/globals.css
@@ -38,3 +38,9 @@ footer > p {
 p > a {
   color: #0c5460 !important;
 }
+
+#spinner {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}

--- a/static/documentation.html
+++ b/static/documentation.html
@@ -118,7 +118,12 @@
           <h1 class="display-3">Documentation</h1>
         </div>
       </div>
-      <div class="container">
+      <div id="spinner">
+        <div class="spinner-border m-5" role="status">
+          <span class="sr-only">Loading...</span>
+        </div>
+      </div>
+      <div id="content-container" style="display: none" class="container">
         <!-- introduction -->
         <div id="introduction-container">
           <h3>Welcome to ELEA!</h3>

--- a/static/scripts/documentation.js
+++ b/static/scripts/documentation.js
@@ -27,6 +27,10 @@ normalBlocks.concat(threadBlocks).forEach((block) => {
   );
 });
 
+// remove loading icon and show content
+document.getElementById("spinner").style.display = "none";
+document.getElementById("content-container").style.display = "block";
+
 function documentation_entry_div(block) {
   let div =
     '<ul class="list-group" id="' +


### PR DESCRIPTION
Adds loading-spinner to `documentation.html`. Content is displayed after complete loading.