### PR TITLE
fix trimmed blocks in documentation

### DIFF
--- a/static/css/documentation.css
+++ b/static/css/documentation.css
@@ -8,7 +8,7 @@
 }
 
 .block-svg > * {
-  width: 50%;
+  width: 100%;
   margin: 0 auto;
 }
 


### PR DESCRIPTION
Fix trimmed block-images in the documentation by increasing the provided width.