### PR TITLE
Edit output functionality

### DIFF
--- a/static/css/workspace.css
+++ b/static/css/workspace.css
@@ -51,13 +51,13 @@ main {
   padding-top: 0.5rem;
 }
 
-#output-header {
+.output-header {
   display: flex;
   flex-direction: row;
   justify-content: space-between;
 }
 
-#output-header > * {
+.output-header > * {
   width: fit-content;
   height: min-content;
 }

--- a/static/css/workspace.css
+++ b/static/css/workspace.css
@@ -62,7 +62,7 @@ main {
   height: min-content;
 }
 
-#output-content {
+#output-print-area {
   background-color: whitesmoke;
   display: flex;
   height: 50vh;

--- a/static/css/workspace.css
+++ b/static/css/workspace.css
@@ -2,6 +2,7 @@ main {
   display: flex;
   justify-content: flex-start;
   flex-direction: column;
+  overflow: hidden;
 }
 
 #workspace-header {
@@ -27,23 +28,22 @@ main {
   width: 100%;
   display: flex;
   flex: 1 1 auto;
+  justify-content: space-between;
 }
 
-#blockly-area,
-#blockly-div {
+#blockly-area {
   width: 70% !important;
   flex: 0 0 70% !important;
   max-width: 70% !important;
 }
 
 #output-column {
-  flex: 1;
   display: flex;
   overflow: auto;
   flex-direction: column;
   width: 30%;
-  margin-left: 0.6rem;
-  margin-right: 0.6rem;
+  padding-left: 0.6rem;
+  padding-right: 0.6rem;
   max-height: 100%;
 }
 

--- a/static/scripts/modules/blocklyHandling.js
+++ b/static/scripts/modules/blocklyHandling.js
@@ -7,10 +7,10 @@ import "regenerator-runtime/runtime";
 import "../ea_blocks";
 import "../newblocks";
 import "../threadblocks";
+import { addPrintOutput } from "../workspace";
 
 // var jsonLog = null;
 var worker = null;
-var outputArea = document.getElementById("output-area");
 var runButton = document.getElementById("run-button");
 
 // var pauseAtNewBlock = true;
@@ -174,6 +174,7 @@ function runCode() {
 
 function handleMessageFromWorker(msg) {
   msg = msg.data;
+  let outputArea = addPrintOutput();
   if (msg.ctrl == "print") {
     if (msg.source)
       outputArea.innerHTML +=

--- a/static/scripts/modules/blocklyHandling.js
+++ b/static/scripts/modules/blocklyHandling.js
@@ -239,10 +239,6 @@ function terminateWorker() {
   runButton.style.backgroundColor = "";
 }
 
-function clearOutput() {
-  outputArea.innerText = "";
-}
-
 // updates the code that appears in the popup whenever a change happens
 // this could probably just be done when the button is pressed, which would reduce console spam
 workspace.addChangeListener(function (event) {
@@ -258,11 +254,4 @@ function setUsingThreads() {
   USING_THREADS = true;
 }
 
-export {
-  setUsingThreads,
-  workspace,
-  runCode,
-  getCode,
-  terminateWorker,
-  clearOutput,
-};
+export { setUsingThreads, workspace, runCode, getCode, terminateWorker };

--- a/static/scripts/workspace.js
+++ b/static/scripts/workspace.js
@@ -68,16 +68,20 @@ function addNewOutputEntry(outputContent, outputContentID, title) {
   <div class="output-block" id="output-${numOutput}">
     <div class="output-header">
       <h3 class="output-heading" id="output-${numOutput}-heading">${title}</h3>
-      <button class="btn btn-outline-dark btn-block" id="output-${numOutput}-button">Hide/Show</button>
+      <button class="btn btn-outline-dark btn-block" id="output-${numOutput}-button">Hide</button>
     </div>
     <div id="output-${numOutput}-content">
       ${outputContent}
     </div>
   </div>`;
   $("#output-column").append(divString);
-  $(`#output-${numOutput}-button`).click(() =>
-    $(`#output-${numOutput}-content`).slideToggle(300)
-  );
+  $(`#output-${numOutput}-button`).click(() => {
+    let newButtonValue = "Show";
+    if ($(`#output-${numOutput}-button`).text() == "Show")
+      newButtonValue = "Hide";
+    $(`#output-${numOutput}-button`).text(newButtonValue);
+    $(`#output-${numOutput}-content`).slideToggle(300);
+  });
   return document.getElementById(outputContentID);
 }
 

--- a/static/scripts/workspace.js
+++ b/static/scripts/workspace.js
@@ -44,6 +44,29 @@ $("#copy_js").click(copyJSToClipboard);
 $("#show_js").click(highlightAll);
 $("#download_json").click(downloadLog);
 
+$("#output-column").height($("#blockly-div").height());
+
 function clearOutput() {
   $("#output-column").empty();
 }
+
+function addNewOutputEntry(outputContent, outputContentID, title) {
+  let numOutput = $("#output-column > *").length;
+  let divString = `
+  <div class="output-block" id="output-${numOutput}">
+    <div class="output-header">
+      <h3 class="output-heading" id="output-${numOutput}-heading">${title}</h3>
+      <button class="btn btn-outline-dark btn-block" id="output-${numOutput}-button">Hide/Show</button>
+    </div>
+    <div id="output-${numOutput}-content">
+      ${outputContent}
+    </div>
+  </div>`;
+  $("#output-column").append(divString);
+  $(`#output-${numOutput}-button`).click(() =>
+    $(`#output-${numOutput}-content`).slideToggle(300)
+  );
+  return document.getElementById(outputContentID);
+}
+
+export { addNewOutputEntry };

--- a/static/scripts/workspace.js
+++ b/static/scripts/workspace.js
@@ -1,8 +1,4 @@
-import {
-  runCode,
-  terminateWorker,
-  clearOutput,
-} from "./modules/blocklyHandling";
+import { runCode, terminateWorker } from "./modules/blocklyHandling";
 import { loadExample } from "./modules/exampleHandling";
 import { selectedFileChanged, promptForXML } from "./modules/import";
 import {
@@ -47,3 +43,7 @@ $("#download_js").click(downloadWorkspaceAsJS);
 $("#copy_js").click(copyJSToClipboard);
 $("#show_js").click(highlightAll);
 $("#download_json").click(downloadLog);
+
+function clearOutput() {
+  $("#output-column").empty();
+}

--- a/static/scripts/workspace.js
+++ b/static/scripts/workspace.js
@@ -46,6 +46,18 @@ $("#download_json").click(downloadLog);
 
 $("#output-column").height($("#blockly-div").height());
 
+function addPrintOutput() {
+  // Check existsence of output entry for printing statements
+  if ($("#output-print-area").length)
+    return document.getElementById("output-print-area");
+  return addNewOutputEntry(
+    '<pre id="output-print-area"></pre>',
+    "output-print-area",
+    "Output"
+  );
+}
+addPrintOutput();
+
 function clearOutput() {
   $("#output-column").empty();
 }
@@ -69,4 +81,4 @@ function addNewOutputEntry(outputContent, outputContentID, title) {
   return document.getElementById(outputContentID);
 }
 
-export { addNewOutputEntry };
+export { addPrintOutput, addNewOutputEntry };

--- a/static/workspace.html
+++ b/static/workspace.html
@@ -235,11 +235,7 @@
       <div id="workspace-content">
         <div id="blockly-area"></div>
         <div id="blockly-div" style="position: absolute"></div>
-        <div id="output-column">
-          <div id="output-content">
-            <pre id="output-area"></pre>
-          </div>
-        </div>
+        <div id="output-column"></div>
       </div>
       <p id="workspace-footer">
         Use blocks from the toolbar on the left to customize your algorithm or


### PR DESCRIPTION
This PR changes the functionality of the output column. Now you can add with `addNewOutputEntry` a new entry to the column. This method generates an entry with a title, a togglable hide and show button, and the inserted div. Afterward, it adds the entry at the end of the column.

Additionally, the print-block uses this functionality. `addPrintOutput` adds and returns an entry to which the MessageHandler sends the messages. If such an entry exists already, it returns the existing element. If you load the webpage, a print-entry will be added by default

In the future, you can add, e.g., plots or other divs to the output column easily.