### PR TITLE
Add loading icon to workspace

### DIFF
--- a/static/css/workspace.css
+++ b/static/css/workspace.css
@@ -82,3 +82,11 @@ main {
     max-width: 1000px; /* New width for default modal */
   }
 }
+
+#spinner {
+  height: 100%;
+  width: 100%;
+  position: absolute;
+  background-color: white;
+  z-index: 1;
+}

--- a/static/scripts/workspace.js
+++ b/static/scripts/workspace.js
@@ -47,3 +47,7 @@ $("#download_js").click(downloadWorkspaceAsJS);
 $("#copy_js").click(copyJSToClipboard);
 $("#show_js").click(highlightAll);
 $("#download_json").click(downloadLog);
+
+// remove loading icon and show content
+document.getElementById("spinner").style.display = "none";
+document.getElementById("workspace-content").style.opacity = "1.0";

--- a/static/workspace.html
+++ b/static/workspace.html
@@ -168,6 +168,11 @@
       </div>
     </nav>
     <main>
+      <div id="spinner">
+        <div class="spinner-border m-5" role="status">
+          <span class="sr-only">Loading...</span>
+        </div>
+      </div>
       <div id="jsModal" class="modal">
         <div class="modal-dialog">
           <div class="modal-content">
@@ -232,7 +237,7 @@
           <!-- <button type="button" class="btn btn-outline-dark btn-block" id="reset-button">Reset execution</button> -->
         </div>
       </div>
-      <div id="workspace-content">
+      <div id="workspace-content" style="opacity: 0">
         <div id="blockly-area"></div>
         <div id="blockly-div" style="position: absolute"></div>
         <div id="output-column">


### PR DESCRIPTION
In this PR, the workspace page shows a loading icon while blockly is loaded when the user opens the page. 
In this way, the user must not see that first the workspace and then the algorithm is loaded. 
It does this by introducing a spinner and setting the opacity of the workspace at zero. The spinner will hide after the workspace is fully loaded and the opacity is set to 1.