### PR TITLE
[exportJS] Use `globalThis` instead of `self`

### DIFF
--- a/static/scripts/MessageHandler.js
+++ b/static/scripts/MessageHandler.js
@@ -50,7 +50,7 @@ class MessageHandler {
 
     // initialise the thread database with the current worker object
     // which will allow for messages to be sent to the parent
-    this.threadMap = new Map([[0, self]]);
+    this.threadMap = new Map([[0, globalThis]]);
   }
 
   // sends a message to the specified location
@@ -93,9 +93,9 @@ class MessageHandler {
     }
 
     // if the message is a variable import request then send a message back to the source of the request
-    // with the value of the given variable, available through the global `self` object
+    // with the value of the given variable, available through the global `globalThis` object
     if (message.ctrl == "import") {
-      this.sendMessage(new Message(message.source, self[message.data]));
+      this.sendMessage(new Message(message.source, globalThis[message.data]));
       return;
     }
 
@@ -208,10 +208,10 @@ function consoleLog(...v) {
 }
 
 //eslint-disable-next-line no-unused-vars -- is used in code blockly compiles
-function consoleerror(e){
-  consolelog(e)
-  consolelog('Find more information in the console.')
-  console.error(e)
+function consoleerror(e) {
+  consolelog(e);
+  consolelog("Find more information in the console.");
+  console.error(e);
 }
 
 // creates the message handler object for the calling script to use
@@ -219,7 +219,7 @@ var Handler = new MessageHandler();
 
 // redirect messages from the parent to the message handler
 // labels the source as having an ID of 0 - the parent's ID
-self.onmessage = function (msg) {
+globalThis.onmessage = function (msg) {
   msg.data.source = Handler.PARENT_ID;
   Handler.handleIncomingMessage(msg.data);
 };

--- a/static/scripts/threadblocks.js
+++ b/static/scripts/threadblocks.js
@@ -18,7 +18,7 @@ Blockly.JavaScript["thread_num"] = function () {
 
 // the available hardware threads on the device
 Blockly.JavaScript["thread_hardware_concurrency"] = function () {
-  var code = "self.navigator.hardwareConcurrency";
+  var code = "globalThis.navigator?.hardwareConcurrency || cpus().length || 1";
   return [code, Blockly.JavaScript.ORDER_NONE];
 };
 


### PR DESCRIPTION
This PR is a preparation for the exportJS feature (#70).

Elea uses `globalThis` instead of `self` because `self` doesn't exist in nodeJS, and the exported version will run on nodeJS. `globalThis` equals `self` if it's executed in the browser. When you run the program with nodeJS, it's `global`.

When you run the program with nodeJS, `globalThis.navigator` doesn't exist. That's why we use `cpu().length` in this case. The import statement for `cpu` will follow in another PR (#70).
