### PR TITLE
[exportJS] rename `main` to `mainFunction`

### DIFF
--- a/static/scripts/MessageHandler.js
+++ b/static/scripts/MessageHandler.js
@@ -112,7 +112,7 @@ class MessageHandler {
         message.source != this.PARENT_ID)
     ) {
       this.pendingRequest = null;
-      main.next(message); //eslint-disable-line no-undef -- is defined in block code
+      globalThis.main.next(message); //eslint-disable-line no-undef -- is defined in block code
       return;
     }
 
@@ -147,7 +147,7 @@ class MessageHandler {
     // we can't resume main until it properly yields, hence we add main to the task queue, and it will be run after
     setTimeout(
       function (msg) {
-        main.next(msg); //eslint-disable-line no-undef -- is defined in block code
+        globalThis.main.next(msg); //eslint-disable-line no-undef -- is defined in block code
       },
       0,
       msg
@@ -191,7 +191,7 @@ class MessageHandler {
   receiveId() {
     if (this.THREAD_ID == null || this.pendingRequest) return;
     setTimeout(function () {
-      main.next(); //eslint-disable-line no-undef -- is defined in block code
+      globalThis.main.next(); //eslint-disable-line no-undef -- is defined in block code
     }, 0);
   }
 }
@@ -208,10 +208,10 @@ function consoleLog(...v) {
 }
 
 //eslint-disable-next-line no-unused-vars -- is used in code blockly compiles
-function consoleerror(e){
-  consolelog(e)
-  consolelog('Find more information in the console.')
-  console.error(e)
+function consoleerror(e) {
+  consolelog(e);
+  consolelog("Find more information in the console.");
+  console.error(e);
 }
 
 // creates the message handler object for the calling script to use

--- a/static/scripts/newblocks.js
+++ b/static/scripts/newblocks.js
@@ -45,7 +45,7 @@ Blockly.JavaScript["ea_init"] = function (block) {
   );
 
   let code = "";
-  code = "function* main() {\n\n";
+  code = "function* mainFunction() {\n\n";
   code += "try {\n";
   code += statements_simulation_steps;
   code += "} catch(e) {\n";
@@ -55,8 +55,8 @@ Blockly.JavaScript["ea_init"] = function (block) {
     '  Handler.sendMessage(new Message(Handler.PARENT_ID, 0, "terminate"));\n';
   code += "};\n";
   code += "}\n";
-  code += "var main = main();\n";
-  code += "main.next();\n";
+  code += "globalThis.main = mainFunction();\n";
+  code += "globalThis.main.next();\n";
   return code;
 };
 

--- a/static/scripts/threadblocks.js
+++ b/static/scripts/threadblocks.js
@@ -97,7 +97,7 @@ function generate_worker_code(statements, return_val) {
   // this necessitates that the code be generated twice for every operation
   PREV_DEFINITIONS = definitions;
 
-  worker_code += "function* main() {\n";
+  worker_code += "function* mainFunction() {\n";
   worker_code += "try {\n";
 
   // execute the internal statements and return the value
@@ -111,7 +111,7 @@ function generate_worker_code(statements, return_val) {
   worker_code += "}\n";
   worker_code += "}\n";
   // the message handler will automatically run main.next() when the THREAD_ID is received
-  worker_code += "var main = main();\n";
+  worker_code += "globalThis.main = mainFunction();\n";
 
   return worker_code;
 }


### PR DESCRIPTION
This PR is a preparation for the exportJS feature (#70).

When you run the program in nodeJS with the old code, you would get an error because `main` is declared twice. This PR renames the function.

Additionally, it saves `main` in a global scope because the exported version will use different import statements. In nodeJS, variables declared with `var` aren't available in the global scope.
