### PR TITLE
[exportJS] differentiate worker

### DIFF
--- a/static/scripts/MessageHandler.js
+++ b/static/scripts/MessageHandler.js
@@ -230,11 +230,11 @@ class JSWorker {
 class NodeWorker {
   constructor(workerData, handler, id) {
     this.newThread = new Worker(workerData, { eval: true });
-    this.newThread.onmessage = function (msg) {
+    this.newThread.on("message", function (msg) {
       msg.source = id;
       msg.sources.unshift(id);
       handler.handleIncomingMessage(msg);
-    };
+    });
   }
 }
 

--- a/static/scripts/MessageHandler.js
+++ b/static/scripts/MessageHandler.js
@@ -53,6 +53,10 @@ class MessageHandler {
     this.threadMap = new Map([[0, self]]);
   }
 
+  setParentPort(parent) {
+    this.threadMap.set(0, parent);
+  }
+
   // sends a message to the specified location
   // if the id is not valid then print a warning to the console
   sendMessage(msg) {


### PR DESCRIPTION
This PR is a preparation for the exportJS feature (#70).

The Web Worker we used doesn't exist in nodeJS. We have to use the thread worker (Another PR will add the missing import statement #70).

Because of this, we can't send messages to `self` or `globalThis`. Instead, we have to send it to `parentPort`. That's why I've added the possibility to change the parentPort.