### PR TITLE
[exportJS] add "start-script" for exported JS

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,10 @@
         "staticPath": "static/examples"
       },
       {
+        "staticOutDir": "export",
+        "staticPath": "static/export"
+      },
+      {
         "staticOutDir": "scripts",
         "staticPath": "static/scripts"
       }

--- a/static/export/main.mjs
+++ b/static/export/main.mjs
@@ -1,0 +1,38 @@
+import {handleLogFromWorker} from "./logging.mjs";
+import { Worker }  from "worker_threads";
+var worker = new Worker("./algorithm.js");
+worker.on("message", handleMessageFromWorker);
+worker.on("error", handleErrorFromWorker);
+function handleMessageFromWorker(msg){
+    if (msg.ctrl == "print") {
+        if (msg.source)
+            console.log("[Thread#" + msg.sources.join(".") + "] " + msg.data + "\n")
+        else
+            console.log(msg.data)
+        return;
+    }
+
+    if (msg.ctrl == "log") {
+        handleLogFromWorker(msg.data);
+        return;
+    }
+
+    // this is sent by the worker when the main function returns
+    if (msg.ctrl == "terminate") {
+        console.log("terminate worker due to its request.");
+        terminateWorker();
+        return;
+    }
+}
+
+function handleErrorFromWorker(err){
+    terminateWorker()
+    throw new Error(err.stack)
+}
+
+function terminateWorker(){
+    if (worker != null) {
+        worker.terminate();
+        console.warn("Terminated running worker");
+    }
+}


### PR DESCRIPTION
This PR is a preparation for the exportJS feature (#70).

This PR adds a script that will be exported with an edited version of `MessageHandler`, `logging`, the algorithm, and a README (#69). `main.mjs` will the start script.