### PR TITLE
[exportJS] differentiate initialization of threads

### DIFF
--- a/static/scripts/threadblocks.js
+++ b/static/scripts/threadblocks.js
@@ -176,7 +176,11 @@ Blockly.JavaScript["run_thread"] = function (block) {
     generate_worker_code(statements_simulation_steps, return_val) +
     "`;\n";
   code +=
-    "_worker_obj = URL.createObjectURL( new Blob([_worker_code], {type: 'application/javascript'}) );\n";
+    "if(typeof process === 'object'){\n" +
+    "\t_worker_obj = _worker_code\n" +
+    "}else{\n" +
+    "\t_worker_obj = URL.createObjectURL( new Blob([_worker_code], {type: 'application/javascript'}) );\n" +
+    "}\n";
   code += "_threads = new Array();\n";
   code += output_array + " = new Array();\n";
   code +=
@@ -278,7 +282,11 @@ Blockly.JavaScript["run_thread_limited"] = function (block) {
     generate_worker_code(statements_simulation_steps, return_val) +
     "`;\n";
   code +=
-    "_worker_obj = URL.createObjectURL( new Blob([_worker_code], {type: 'application/javascript'}) );\n";
+    "if(typeof process === 'object'){\n" +
+    "\t_worker_obj = _worker_code\n" +
+    "}else{\n" +
+    "\t_worker_obj = URL.createObjectURL( new Blob([_worker_code], {type: 'application/javascript'}) );\n" +
+    "}\n";
   code += "_threads = new Array();\n";
   code += output_array + " = new Array();\n";
   code +=


### PR DESCRIPTION
This PR is a preparation for the exportJS feature (#70).

We have to use thread worker because we can't use Web Worker in nodeJS. These have to be initialized differently. You can run them without using blobs, just with the flag `{eval: true}` in the initialization of the worker itself (#65).