### PR TITLE
remove copy JS button

### DIFF
--- a/static/scripts/modules/export.js
+++ b/static/scripts/modules/export.js
@@ -9,12 +9,6 @@ function copyXMLToClipboard() {
   resetHasUnsavedChangesHandling();
 }
 
-function copyJSToClipboard() {
-  var js = getCode();
-  copyToClipboard(js);
-  resetHasUnsavedChangesHandling();
-}
-
 function download(text, name, type) {
   var file = new Blob([text], { type: type });
   downloadFile(file, name);
@@ -35,6 +29,5 @@ export {
   downloadWorkspace,
   copyXMLToClipboard,
   downloadWorkspaceAsJS,
-  copyJSToClipboard,
   downloadFile,
 };

--- a/static/scripts/workspace.js
+++ b/static/scripts/workspace.js
@@ -2,7 +2,6 @@ import { runCode, terminateWorker } from "./modules/blocklyHandling";
 import { loadExample } from "./modules/exampleHandling";
 import { selectedFileChanged, promptForXML } from "./modules/import";
 import {
-  copyJSToClipboard,
   copyXMLToClipboard,
   downloadWorkspace,
   downloadWorkspaceAsJS,
@@ -40,7 +39,6 @@ $("#promt_for_xml").click(promptForXML);
 $("#download_xml").click(downloadWorkspace);
 $("#copy_xml").click(copyXMLToClipboard);
 $("#download_js").click(downloadWorkspaceAsJS);
-$("#copy_js").click(copyJSToClipboard);
 $("#show_js").click(highlightAll);
 $("#download_json").click(downloadLog);
 

--- a/static/workspace.html
+++ b/static/workspace.html
@@ -129,7 +129,6 @@
               <a class="dropdown-item" id="download_js" href="#">
                 Download JS file
               </a>
-              <a class="dropdown-item" id="copy_js" href="#">Copy JS string</a>
               <a
                 class="dropdown-item"
                 data-toggle="modal"


### PR DESCRIPTION
Removes the copyJS button, because it doesn't make sense after #70 to copy the JS version of the algorithm. It's now a bundle of JS-files.