### PR TITLE
Fix documentation endless loading

### DIFF
--- a/static/blockDefinition/normalBlocks.js
+++ b/static/blockDefinition/normalBlocks.js
@@ -896,6 +896,6 @@ export const blockDefinitions = [
     tooltip:
       "Returns true when no individual from the population has the requested fitness",
     helpUrl: "",
-    category: "Logic",
+    category: "logic",
   },
 ];


### PR DESCRIPTION
I fixed the endless loading of the documentation by renaming the category of "check_fitness" from "Logic" to "logic" because every category starts with a small letter.