### PR TITLE
[csv] add csv functionality to exported version

### DIFF
--- a/static/export/main.mjs
+++ b/static/export/main.mjs
@@ -1,4 +1,5 @@
 import {handleLogFromWorker} from "./logging.mjs";
+import { downloadCSV, updateValue } from "./CSVHandler.mjs";
 import { Worker }  from "worker_threads";
 var worker = new Worker("./algorithm.js");
 worker.on("message", handleMessageFromWorker);
@@ -17,6 +18,11 @@ function handleMessageFromWorker(msg){
         return;
     }
 
+    if(msg.ctrl == "csv") {
+        updateValue(msg.data);
+        return;
+    }
+
     // this is sent by the worker when the main function returns
     if (msg.ctrl == "terminate") {
         console.log("terminate worker due to its request.");
@@ -27,6 +33,7 @@ function handleMessageFromWorker(msg){
 
 function handleErrorFromWorker(err){
     terminateWorker()
+    downloadCSV();
     throw new Error(err.stack)
 }
 


### PR DESCRIPTION
This PR adds the ability to generate CSV files to the exported version. The user can download the blockly code, let it run on a server, and collect data in CSV files. It does this by handling the new message type "csv" and exporting the CSV Handler.

Please review and merge after you merge #92 