### PR TITLE
make init-block unique

### DIFF
--- a/static/blockDefinition/normalBlocks.js
+++ b/static/blockDefinition/normalBlocks.js
@@ -16,7 +16,7 @@ export const blockDefinitions = [
       },
     ],
     colour: 230,
-    tooltip: "This block runs if you click 'Run Javascript'.",
+    tooltip: "This block runs if you click 'Run'.",
     helpUrl: "",
     category: "algorithm-parts",
   },

--- a/static/examples/empty.xml
+++ b/static/examples/empty.xml
@@ -1,3 +1,3 @@
 <xml xmlns="https://developers.google.com/blockly/xml" id="startBlocks" style="display: none">
-    <block type="ea_init" id="YT[Lu2`Gez~7AXe!qUn4" x="186" y="38"></block>
+    <block type="ea_init" id="YT[Lu2`Gez~7AXe!qUn4" x="186" y="38" deletable="false"></block>
 </xml>

--- a/static/examples/full.xml
+++ b/static/examples/full.xml
@@ -13,7 +13,7 @@
     <variable type="Individual" id="|5zDPSJN?$Di|I!M#17|">parent</variable>
     <variable type="Individual" id="DL-dyiHx%dpP^R1wV9n#">offspring</variable>
   </variables>
-  <block type="ea_init" id="YT[Lu2`Gez~7AXe!qUn4" x="165" y="4">
+  <block type="ea_init" id="YT[Lu2`Gez~7AXe!qUn4" x="165" y="4" deletable="false">
     <statement name="init_statements">
       <block type="controls_for" id="}XR@KNXf}G(1Dm;n:tdN">
         <field name="VAR" id="$zt),?8|})G,(/E.43Jj">count</field>

--- a/static/examples/full_multithread.xml
+++ b/static/examples/full_multithread.xml
@@ -13,7 +13,7 @@
     <variable type="Individual" id="]3vGA_2znq/0l?#sZ~44">parent</variable>
     <variable type="Individual" id="HQzB2Dh:AnHS2Splu_vY">offspring</variable>
   </variables>
-  <block type="ea_init" id="YT[Lu2`Gez~7AXe!qUn4" x="165" y="-17">
+  <block type="ea_init" id="YT[Lu2`Gez~7AXe!qUn4" x="165" y="-17" deletable="false">
     <statement name="init_statements">
       <block type="run_thread" id="v3_MRZXz1chSWMiQ0Y2X">
         <field name="output_array" id="jpSMP=UtW)m]Fg0W0FxU">result</field>

--- a/static/examples/multithread-performance.xml
+++ b/static/examples/multithread-performance.xml
@@ -5,7 +5,7 @@
     <variable id="b!@f8OP^Ceri}:0Ul5Bc">fib</variable>
     <variable id="99$amqG0$ExBHhp3:,@l">result</variable>
   </variables>
-  <block type="ea_init" id="YT[Lu2`Gez~7AXe!qUn4" x="59" y="86">
+  <block type="ea_init" id="YT[Lu2`Gez~7AXe!qUn4" x="59" y="86" deletable="false">
     <statement name="init_statements">
       <block type="comment" id="LOwOwZ$D:tC_z0l6cSaM">
         <field name="text">Demonstrate how different multithread methods &amp;#10;influence the runtime of the algorithm by &amp;#10;performing the same calculation in different &amp;#10;numbers of threads</field>

--- a/static/examples/multithread.xml
+++ b/static/examples/multithread.xml
@@ -4,7 +4,7 @@
     <variable id="*b+Q}ingpG7]CAE,M{GD">fib</variable>
     <variable id="Y%7;kKJwF1UkHI{DSg}B">i</variable>
   </variables>
-  <block type="ea_init" id="YT[Lu2`Gez~7AXe!qUn4" x="435" y="49">
+  <block type="ea_init" id="YT[Lu2`Gez~7AXe!qUn4" x="435" y="49" deletable="false">
     <statement name="init_statements">
       <block type="ea_debug" id="bPacL4PJ]5kT._h=}*9K">
         <value name="logging_variable">

--- a/static/examples/onelambda.xml
+++ b/static/examples/onelambda.xml
@@ -9,7 +9,7 @@
     <variable type="Array" id="~;*AsD@4827rMP/(fs1P">offspring_population</variable>
     <variable type="Individual" id="*5^D:E8Zu~=@S8sXG([6">offspring</variable>
   </variables>
-  <block type="ea_init" id="YT[Lu2`Gez~7AXe!qUn4" x="191" y="42">
+  <block type="ea_init" id="YT[Lu2`Gez~7AXe!qUn4" x="191" y="42" deletable="false">
     <statement name="init_statements">
       <block type="variables_set" id="bJ)@xkyp}@=FnLiM1~QW">
         <field name="VAR" id="-*|uDjwhmvz~~T(Am;%J">λ</field>

--- a/static/examples/onepluslambda.xml
+++ b/static/examples/onepluslambda.xml
@@ -9,7 +9,7 @@
     <variable type="Array" id="%qRD51o0DIN%L(_4#A_C">offspring_population</variable>
     <variable type="Individual" id=";/@Mb$_^TZcT{o2sG:_c">offspring</variable>
   </variables>
-  <block type="ea_init" id="YT[Lu2`Gez~7AXe!qUn4" x="191" y="42">
+  <block type="ea_init" id="YT[Lu2`Gez~7AXe!qUn4" x="191" y="42" deletable="false">
     <statement name="init_statements">
       <block type="variables_set" id="bJ)@xkyp}@=FnLiM1~QW">
         <field name="VAR" id="-*|uDjwhmvz~~T(Am;%J">λ</field>

--- a/static/examples/oneplusone.xml
+++ b/static/examples/oneplusone.xml
@@ -7,7 +7,7 @@
     <variable id="0dkovK!SuoHH%uP1/Uc}">chi</variable>
     <variable type="Individual" id="/tnRua%7/_s9G4(pG,{t">offspring</variable>
   </variables>
-  <block type="ea_init" id="YT[Lu2`Gez~7AXe!qUn4" x="191" y="42">
+  <block type="ea_init" id="YT[Lu2`Gez~7AXe!qUn4" x="191" y="42" deletable="false">
     <statement name="init_statements">
       <block type="variables_set" id="XSr6{9T}`^/@y8^EVzaL">
         <field name="VAR" id="v`D6r417R_rR.AyGB:]O">n</field>

--- a/static/examples/simple.xml
+++ b/static/examples/simple.xml
@@ -11,7 +11,7 @@
     <variable type="Individual" id="*hQa)e/ODpP;0mfHAvfO">offspring1</variable>
     <variable type="Individual" id=":^Fp=6cFPi#KWNQDa#;u">offspring2</variable>
   </variables>
-  <block type="ea_init" id="YT[Lu2`Gez~7AXe!qUn4" x="186" y="38">
+  <block type="ea_init" id="YT[Lu2`Gez~7AXe!qUn4" x="186" y="38" deletable="false">
     <statement name="init_statements">
       <block type="variables_set" id="N8=or.WL#9!rDUnQrGuL">
         <field name="VAR" id="_`RU](?6R2Mdm}^monre">genome_length</field>

--- a/static/workspace.html
+++ b/static/workspace.html
@@ -262,7 +262,6 @@
         <block type="individual_hamming_distance"></block>
       </category>
       <category name="Algorithm parts" colour="230">
-        <block type="ea_init"></block>
         <block type="init_uniform"></block>
         <block type="init_constant"></block>
         <block type="pop_init"></block>


### PR DESCRIPTION
Removing the init-block from the toolkit and making it undeletable ensures that each workspace contains exactly one. 