### PR TITLE
Add logging of CSVHandler to output

### DIFF
--- a/static/scripts/MessageHandler.js
+++ b/static/scripts/MessageHandler.js
@@ -213,6 +213,15 @@ function plot(v) {
 
 //eslint-disable-next-line no-unused-vars -- is used in code blockly compiles
 function save_in_csv(v) {
+  consolelog(
+    "added '" +
+      v.value +
+      "' to dataset '" +
+      v.datasetname +
+      "' in file '" +
+      v.filename +
+      "'"
+  );
   Handler.sendMessage(new Message(Handler.PARENT_ID, v, "csv"));
 }
 


### PR DESCRIPTION
This PR added a log entry to the output when the user added a new datapoint to a CSV file. Now, the process of the CSVHandler is visible. It adds the functionality by sending an additional message to the MessageHandler in the `save_in_csv`.