### PR TITLE
Zip exported CSV files

### DIFF
--- a/static/scripts/modules/export.js
+++ b/static/scripts/modules/export.js
@@ -29,6 +29,7 @@ async function downloadWorkspaceAsJS() {
   let readme = await read_file("./export/README.md");
   let main = await read_file("./export/main.mjs");
   let logging = await read_file("./scripts/modules/logging.js");
+  let jszip = await read_file("./scripts/jszip.js");
   if (
     ![algorithm, message_handler, csv_handler, readme, main, logging].every(
       (f) => f != false
@@ -44,6 +45,7 @@ async function downloadWorkspaceAsJS() {
   zip.file("README.md", readme);
   zip.file("main.mjs", main);
   zip.file("logging.mjs", logging);
+  zip.file("jszip.js", jszip);
   let zip_file = await zip.generateAsync({ type: "blob" });
   downloadFile(zip_file, "elea.zip");
 }


### PR DESCRIPTION
After this PR, exported CSV files are bundled in a single zip file instead of separate downloads. 

It adds this functionality by replacing the separate downloads with adding them to a zip file. Because this zip file isn't plain text, it has to generate differently depending on the environment. JSZip generates the file as a nodebuffer-element in a node environment and as a blob in the browser.