### PR TITLE
Use `field_input` for datasetname

### DIFF
--- a/static/blockDefinition/normalBlocks.js
+++ b/static/blockDefinition/normalBlocks.js
@@ -888,9 +888,10 @@ export const blockDefinitions = [
         comment: "value of the new datapoint",
       },
       {
-        type: "input_value",
-        name: "datasetNumber",
-        check: "Number",
+        type: "field_input",
+        name: "datasetName",
+        text: "dataset",
+        check: ["String", "Number"],
         comment:
           "Determines to which dataset of the plot this data will be added.",
       },
@@ -929,9 +930,10 @@ export const blockDefinitions = [
         comment: "value of the new datapoint",
       },
       {
-        type: "input_value",
+        type: "field_input",
         name: "datasetname",
-        check: "String",
+        text: "dataset",
+        check: ["String", "Number"],
         comment:
           "Determines to which column of the CSV-file this data will be added.",
       },

--- a/static/scripts/PlotHandler.js
+++ b/static/scripts/PlotHandler.js
@@ -1,126 +1,130 @@
 import { addNewOutputEntry } from "./workspace";
 
 class PlotHandler {
-    constructor() {
-        this.plotMap = new Map();
+  constructor() {
+    this.plotMap = new Map();
+  }
+  //the data forwarded contains a single object of type {yValue,datasetName,plotName,plotType}
+  //because of the message handling this object is the first element of the data-array
+  //forward the data to the correct PlotWorker or create one if necessary
+  updateValue(data) {
+    let plotName = data.plotName;
+    let requestedPlot = this.plotMap.get(plotName);
+    if (!requestedPlot) {
+      requestedPlot = new PlotWorker(plotName, data.plotType);
+      this.plotMap.set(plotName, requestedPlot);
     }
-    //the data forwarded contains a single object of type {yValue,datasetNumber,plotName,plotType}
-    //because of the message handling this object is the first element of the data-array
-    //forward the data to the correct PlotWorker or create one if necessary 
-    updateValue(data) {
-        let plotName = data.plotName;
-        let requestedPlot = this.plotMap.get(plotName);
-        if (!requestedPlot) {
-            requestedPlot = new PlotWorker(plotName, data.plotType);
-            this.plotMap.set(plotName, requestedPlot);
-        }
-        requestedPlot.updateValue(data);
-    }
+    requestedPlot.updateValue(data);
+  }
 
-    drawPlots() {
-        this.plotMap.forEach((value) => value.drawPlot());
-    }
+  drawPlots() {
+    this.plotMap.forEach((value) => value.drawPlot());
+  }
 
-    clearPlots() {
-        this.plotMap = new Map();
-    }
+  clearPlots() {
+    this.plotMap = new Map();
+  }
 }
 
 class PlotWorker {
-    constructor(name, plotType) {
-        this.plotName = name;
-        this.plotData = new Map();
-        this.plotType = plotType;
-        this.myChart = null;
-        this.chartExists = false;
-        this.labels = [1];
-        this.iteration = 0;
-        let divString = `<canvas id="plot-${name}"></canvas>`;
-        addNewOutputEntry(
-            divString,
-            name,
-            name
-        );
-        let canvasID = 'plot-' + name;
-        this.chartArea = document.getElementById(canvasID).getContext('2d');
+  constructor(name, plotType) {
+    this.plotName = name;
+    this.plotData = new Map();
+    this.plotType = plotType;
+    this.myChart = null;
+    this.chartExists = false;
+    this.labels = [1];
+    this.iteration = 0;
+    let divString = `<canvas id="plot-${name}"></canvas>`;
+    addNewOutputEntry(divString, name, name);
+    let canvasID = "plot-" + name;
+    this.chartArea = document.getElementById(canvasID).getContext("2d");
+  }
+
+  //collect data during runtime
+  updateValue(data) {
+    let datasetName = data.datasetName;
+    if (this.iteration > 0) {
+      // new runs produce new datasets which can be distinguished by their ending
+      datasetName += "_" + this.iteration;
     }
-
-    //collect data during runtime 
-    updateValue(data) {
-        let datasetName = data.datasetNumber;
-        if (this.iteration > 0) {
-            // new runs produce new datasets which can be distinguished by their ending 
-            datasetName += "_" + this.iteration;
-        }
-        let dataset = this.plotData.get(datasetName);
-        if (!dataset) {
-            dataset = {
-                label: 'Dataset' + datasetName,
-                backgroundColor: random_rgba(),
-                data: [data.yValue],
-            }
-            this.plotData.set(datasetName, dataset);
-        } else {
-            dataset.data.push(data.yValue);
-            if (dataset.data.length > this.labels.length) {
-                this.labels.push(dataset.data.length);
-            }
-        }
+    let dataset = this.plotData.get(datasetName);
+    if (!dataset) {
+      dataset = {
+        label: "Dataset " + datasetName,
+        backgroundColor: random_rgba(),
+        data: [data.yValue],
+      };
+      this.plotData.set(datasetName, dataset);
+    } else {
+      dataset.data.push(data.yValue);
+      if (dataset.data.length > this.labels.length) {
+        this.labels.push(dataset.data.length);
+      }
     }
+  }
 
-    drawPlot() {
-        this.iteration++;
-        if (!this.chartExists) {
+  drawPlot() {
+    this.iteration++;
+    if (!this.chartExists) {
+      let testplotData = {
+        labels: this.labels,
+        datasets: Array.from(this.plotData.values()),
+      };
+      const config = {
+        type: this.plotType,
+        data: testplotData,
+        options: {
+          plugins: {
+            title: {
+              display: true,
+              text: this.plotName,
+            },
+          },
+        },
+      };
 
-            let testplotData = {
-                labels: this.labels,
-                datasets: Array.from(this.plotData.values()),
-            };
-            const config = {
-                type: this.plotType,
-                data: testplotData,
-                options: {
-                    plugins: {
-                        title: {
-                            display: true,
-                            text: this.plotName
-                        }
-                    },
-                },
-            };
-
-            this.myChart = new Chart(//eslint-disable-line no-undef -- is defined in block code
-                this.chartArea,
-                config
-            );
-            this.chartExists = true;
-        } else {
-            this.myChart.data.datasets = Array.from(this.plotData.values());
-            this.myChart.update();
-        }
-        return;
+      this.myChart = new Chart(this.chartArea, config); //eslint-disable-line no-undef -- is defined in block code
+      this.chartExists = true;
+    } else {
+      this.myChart.data.datasets = Array.from(this.plotData.values());
+      this.myChart.update();
     }
+    return;
+  }
 }
 
 var plotHandler = new PlotHandler();
 
 function updateValue(data) {
-    plotHandler.updateValue(data);
+  plotHandler.updateValue(data);
 }
 
 function drawPlots() {
-    plotHandler.drawPlots();
+  plotHandler.drawPlots();
 }
 
 function clearPlots() {
-    plotHandler.clearPlots();
+  plotHandler.clearPlots();
 }
 
-//use a random color for every dataset for now 
+//use a random color for every dataset for now
 // after the PR for the new color scheme is completed, the plots colors will be based on that
 function random_rgba() {
-    var o = Math.round, r = Math.random, s = 255;
-    return 'rgba(' + o(r() * s) + ',' + o(r() * s) + ',' + o(r() * s) + ',' + r().toFixed(1) + ')';
+  var o = Math.round,
+    r = Math.random,
+    s = 255;
+  return (
+    "rgba(" +
+    o(r() * s) +
+    "," +
+    o(r() * s) +
+    "," +
+    o(r() * s) +
+    "," +
+    r().toFixed(1) +
+    ")"
+  );
 }
 
-export { updateValue, drawPlots, clearPlots }; 
+export { updateValue, drawPlots, clearPlots };

--- a/static/scripts/newblocks.js
+++ b/static/scripts/newblocks.js
@@ -791,17 +791,13 @@ Blockly.JavaScript["plotting_one_value"] = function (block) {
     "yValue",
     Blockly.JavaScript.ORDER_ATOMIC
   );
-  var variable_datasetNumber = Blockly.JavaScript.valueToCode(
-    block,
-    "datasetNumber",
-    Blockly.JavaScript.ORDER_ATOMIC
-  );
+  var variable_datasetName = block.getFieldValue("datasetName");
   var variable_plotName = block.getFieldValue("plotName");
   var variable_plotType = block.getFieldValue("plotType");
 
   var code = "plot({yValue: ";
-  code += variable_yValue + ", datasetNumber: ";
-  code += variable_datasetNumber + ", plotName: ";
+  code += variable_yValue + ", datasetName: ";
+  code += "'" + variable_datasetName + "', plotName: ";
   code += "'" + variable_plotName + "', plotType: ";
   code += "'" + variable_plotType + "'});\n";
   return code;
@@ -813,16 +809,12 @@ Blockly.JavaScript["save_in_csv"] = function (block) {
     "value",
     Blockly.JavaScript.ORDER_ATOMIC
   );
-  var variable_datasetName = Blockly.JavaScript.valueToCode(
-    block,
-    "datasetname",
-    Blockly.JavaScript.ORDER_ATOMIC
-  );
+  var variable_datasetName = block.getFieldValue("datasetname");
   var variable_plotName = block.getFieldValue("filename");
 
   var code = "save_in_csv({value: ";
   code += variable_value + ", datasetname: ";
-  code += variable_datasetName + ", filename: ";
+  code += "'" + variable_datasetName + "', filename: ";
   code += "'" + variable_plotName + "'});\n";
   return code;
 };

--- a/static/workspace.html
+++ b/static/workspace.html
@@ -315,23 +315,7 @@
         </block>
         <block type="text"></block>
         <block type="comment"></block>
-        <block type="plotting_one_value">
-          <value name="yValue">
-            <shadow type="math_number">
-              <field name="NUM">10</field>
-            </shadow>
-          </value>
-          <value name="datasetNumber">
-            <shadow type="math_number">
-              <field name="NUM">1</field>
-            </shadow>
-          </value>
-          <value name="plotName">
-            <shadow type="math_number">
-              <field name="NUM">fitness</field>
-            </shadow>
-          </value>
-        </block>
+        <block type="plotting_one_value"></block>
         <block type="save_in_csv"></block>
       </category>
       <sep></sep>


### PR DESCRIPTION
After this PR, the user can type in the datasetname of a plot or CSV-file instead of using an additional block. This improves usability. Additionally, I replaced datasetnumber with datasetname in the plot-block to align this style with the CSV-block. Furthermore, this PR removes the example data in the plot-block.