### PR TITLE
Edit types of datasetname in logging blocks

### DIFF
--- a/static/blockDefinition/normalBlocks.js
+++ b/static/blockDefinition/normalBlocks.js
@@ -890,7 +890,7 @@ export const blockDefinitions = [
       {
         type: "input_value",
         name: "datasetNumber",
-        check: "Number",
+        check: ["String", "Number"],
         comment:
           "Determines to which dataset of the plot this data will be added.",
       },
@@ -931,7 +931,7 @@ export const blockDefinitions = [
       {
         type: "input_value",
         name: "datasetname",
-        check: "String",
+        check: ["String", "Number"],
         comment:
           "Determines to which column of the CSV-file this data will be added.",
       },

--- a/static/workspace.html
+++ b/static/workspace.html
@@ -332,7 +332,13 @@
             </shadow>
           </value>
         </block>
-        <block type="save_in_csv"></block>
+        <block type="save_in_csv">
+          <value name="datasetname">
+            <shadow type="text">
+              <field name="TEXT">fitness</field>
+            </shadow>
+          </value>
+        </block>
       </category>
       <sep></sep>
       <category name="Variables" colour="330">


### PR DESCRIPTION
With this PR, plot- and csv-blocks allow Number and String values now. To help the user I added a text field per default to the csv block.