### PR TITLE
rename saved CSV file in exported project

### DIFF
--- a/static/scripts/CSVHandler.js
+++ b/static/scripts/CSVHandler.js
@@ -112,7 +112,7 @@ async function downloadZIP(zip) {
     // Nodejs environment
     zip.generateAsync({ type: "nodebuffer" }).then(function (content) {
       //eslint-disable-next-line no-undef -- is imported in nodejs env
-      fs.writeFile("hello.zip", content, function (e) {
+      fs.writeFile("elea-csv.zip", content, function (e) {
         if (e) return console.error(e);
       });
     });


### PR DESCRIPTION
I renamed the saved CSV file in the exported project version from `hello.zip` to `elea-csv.zip`, because it was a placeholder.