### PR TITLE
Move saving file in node env from CSVHandler to fileUtils

### DIFF
--- a/static/scripts/CSVHandler.js
+++ b/static/scripts/CSVHandler.js
@@ -1,6 +1,6 @@
 import { addNewOutputEntry } from "./workspace";
 import JSZip from "./jszip.js";
-import { downloadFile } from "./modules/fileUtils";
+import { downloadFile, saveFileNode } from "./modules/fileUtils";
 
 class CSVHandler {
   constructor() {
@@ -112,10 +112,7 @@ async function downloadZIP(zip) {
   if (!globalThis.window) {
     // Nodejs environment
     zip.generateAsync({ type: "nodebuffer" }).then(function (content) {
-      //eslint-disable-next-line no-undef -- is imported in nodejs env
-      fs.writeFile("elea-csv.zip", content, function (e) {
-        if (e) return console.error(e);
-      });
+      saveFileNode(content, "elea-csv.zip");
     });
   } else {
     // Browser environment

--- a/static/scripts/modules/export.js
+++ b/static/scripts/modules/export.js
@@ -25,11 +25,11 @@ function downloadWorkspace() {
 async function downloadWorkspaceAsJS() {
   let algorithm = await prepare_algorithm();
   let message_handler = await prepare_messagerhandler();
-  let csv_handler = await read_file("./scripts/CSVHandler.js");
-  let readme = await read_file("./export/README.md");
-  let main = await read_file("./export/main.mjs");
-  let logging = await read_file("./scripts/modules/logging.js");
-  let jszip = await read_file("./scripts/jszip.js");
+  let csv_handler = await readFile("./scripts/CSVHandler.js");
+  let readme = await readFile("./export/README.md");
+  let main = await readFile("./export/main.mjs");
+  let logging = await readFile("./scripts/modules/logging.js");
+  let jszip = await readFile("./scripts/jszip.js");
   let fileutils = await prepare_fileUtils();
 
   if (
@@ -102,7 +102,7 @@ function prepare_algorithm() {
 
 async function prepare_fileUtils() {
   let file;
-  if (!(file = await read_file("./scripts/modules/fileUtils.js"))) return false;
+  if (!(file = await readFile("./scripts/modules/fileUtils.js"))) return false;
   let code = `import fs from "fs";\n`;
   code += file;
   return code;

--- a/static/scripts/modules/export.js
+++ b/static/scripts/modules/export.js
@@ -25,12 +25,12 @@ function downloadWorkspace() {
 async function downloadWorkspaceAsJS() {
   let algorithm = await prepare_algorithm();
   let message_handler = await prepare_messagerhandler();
-  let csv_handler = await prepare_csvhandler();
+  let csv_handler = await read_file("./scripts/CSVHandler.js");
   let readme = await read_file("./export/README.md");
   let main = await read_file("./export/main.mjs");
   let logging = await read_file("./scripts/modules/logging.js");
   let jszip = await read_file("./scripts/jszip.js");
-  let fileutils = await read_file("./scripts/modules/fileUtils.js");
+  let fileutils = await prepare_fileUtils();
   if (
     ![algorithm, message_handler, csv_handler, readme, main, logging].every(
       (f) => f != false
@@ -99,9 +99,9 @@ function prepare_algorithm() {
   return tmp;
 }
 
-async function prepare_csvhandler() {
+async function prepare_fileUtils() {
   let file;
-  if (!(file = await read_file("./scripts/CSVHandler.js"))) return false;
+  if (!(file = await read_file("./scripts/modules/fileUtils.js"))) return false;
   let code = `import fs from "fs";\n`;
   code += file;
   return code;

--- a/static/scripts/modules/fileUtils.js
+++ b/static/scripts/modules/fileUtils.js
@@ -12,6 +12,13 @@ function downloadFile(blob, fileName) {
   setTimeout(() => URL.revokeObjectURL(link.href), 7000);
 }
 
+function saveFileNode(nodebuffer, fileName) {
+  //eslint-disable-next-line no-undef -- is imported in nodejs env
+  fs.writeFile(fileName, nodebuffer, function (e) {
+    if (e) return console.error(e);
+  });
+}
+
 function copyToClipboard(str) {
   const el = document.createElement("textarea");
   el.value = str;
@@ -21,4 +28,4 @@ function copyToClipboard(str) {
   document.body.removeChild(el);
 }
 
-export { downloadFile, copyToClipboard };
+export { downloadFile, saveFileNode, copyToClipboard };

--- a/static/scripts/modules/fileUtils.js
+++ b/static/scripts/modules/fileUtils.js
@@ -23,7 +23,6 @@ async function readFile(path) {
   let response = await fetch(path);
   if (!response.ok) return false;
   return await response.text();
-
 }
 
 function copyToClipboard(str) {
@@ -35,4 +34,4 @@ function copyToClipboard(str) {
   document.body.removeChild(el);
 }
 
-export { downloadFile, saveFileNode, copyToClipboard };
+export { downloadFile, saveFileNode, copyToClipboard, readFile };


### PR DESCRIPTION
This PR moves the saving operation in the node environment from the CSVHandler to fileUtils to clarify the responsibilities. I did this by extracting a method and moving the import statement of `fs` from CSVHandler to fileUtils in the exported project.