### PR TITLE
Rename downloadFile to saveFileBrowser

### DIFF
--- a/static/scripts/CSVHandler.js
+++ b/static/scripts/CSVHandler.js
@@ -1,6 +1,6 @@
 import { addNewOutputEntry } from "./workspace";
 import JSZip from "./jszip.js";
-import { downloadFile } from "./modules/fileUtils";
+import { saveFileBrowser } from "./modules/fileUtils";
 
 class CSVHandler {
   constructor() {
@@ -120,7 +120,7 @@ async function downloadZIP(zip) {
   } else {
     // Browser environment
     let file = await zip.generateAsync({ type: "blob" });
-    downloadFile(file, "elea-csv.zip");
+    saveFileBrowser(file, "elea-csv.zip");
   }
 }
 

--- a/static/scripts/modules/export.js
+++ b/static/scripts/modules/export.js
@@ -2,7 +2,7 @@ import * as Blockly from "blockly";
 import { resetHasUnsavedChangesHandling } from "./unsavedChangesHandling";
 import { workspace, getCode } from "./blocklyHandling";
 import { logDB } from "./logging";
-import { downloadFile, copyToClipboard } from "./fileUtils";
+import { saveFileBrowser as saveFile, copyToClipboard } from "./fileUtils";
 import JSZip from "../jszip";
 
 function copyXMLToClipboard() {
@@ -13,7 +13,7 @@ function copyXMLToClipboard() {
 
 function download(text, name, type) {
   var file = new Blob([text], { type: type });
-  downloadFile(file, name);
+  saveFile(file, name);
   resetHasUnsavedChangesHandling();
 }
 
@@ -50,7 +50,7 @@ async function downloadWorkspaceAsJS() {
   zip.folder("modules");
   zip.file("modules/fileUtils.js", fileutils);
   let zip_file = await zip.generateAsync({ type: "blob" });
-  downloadFile(zip_file, "elea.zip");
+  saveFile(zip_file, "elea.zip");
 }
 
 async function prepare_messagerhandler() {
@@ -191,13 +191,12 @@ async function downloadLog() {
   }
 
   let file = await zip.generateAsync({ type: "blob" });
-  downloadFile(file, "log.zip");
+  saveFile(file, "log.zip");
 }
 
 export {
   downloadWorkspace,
   copyXMLToClipboard,
   downloadWorkspaceAsJS,
-  downloadFile,
   downloadLog,
 };

--- a/static/scripts/modules/fileUtils.js
+++ b/static/scripts/modules/fileUtils.js
@@ -1,5 +1,5 @@
 // this function was taken from: https://stackoverflow.com/a/52829183
-function downloadFile(blob, fileName) {
+function saveFileBrowser(blob, fileName) {
   const link = document.createElement("a");
   // create a blobURI pointing to our Blob
   link.href = URL.createObjectURL(blob);
@@ -21,4 +21,4 @@ function copyToClipboard(str) {
   document.body.removeChild(el);
 }
 
-export { downloadFile, copyToClipboard };
+export { saveFileBrowser, copyToClipboard };


### PR DESCRIPTION
This PR renames the function `downloadFile` in fileUtils.js to `saveFileBrowser` to align the naming with `saveFileNode` in #129.