### PR TITLE
Fix endless documentation loading

### DIFF
--- a/static/blockDefinition/normalBlocks.js
+++ b/static/blockDefinition/normalBlocks.js
@@ -946,7 +946,7 @@ export const blockDefinitions = [
   },
   {
     type: "plotting_two_values",
-    message0: "Plot x:%1 y: %2 in Dataset: %3 in Plot: %4 as %5",
+    message0: "Plot x: %1 y: %2 in Dataset: %3 in Plot: %4 as %5",
     args0: [
       {
         type: "input_value",


### PR DESCRIPTION
A bug occurred, which implicates the endless loading of the documentation. I fixed it by adding a space to the block definition of `plotting_two_values`. The missing space broke the splitting of spaces and fetching the arguments.