### PR TITLE
Fix imports in CSVHandler for node environment

### DIFF
--- a/static/scripts/CSVHandler.js
+++ b/static/scripts/CSVHandler.js
@@ -1,6 +1,6 @@
 import { addNewOutputEntry } from "./workspace";
+import { saveFileBrowser, saveFileNode } from "./modules/fileUtils.js";
 import JSZip from "./jszip.js";
-import { saveFileBrowser, saveFileNode } from "./modules/fileUtils";
 
 class CSVHandler {
   constructor() {

--- a/static/scripts/CSVHandler.js
+++ b/static/scripts/CSVHandler.js
@@ -1,5 +1,5 @@
 import { addNewOutputEntry } from "./workspace";
-import { saveFileBrowser, saveFileNode } from "./modules/fileUtils.js";
+import { saveFileBrowser, saveFileNode } from "./modules/fileUtils";
 import JSZip from "./jszip.js";
 
 class CSVHandler {

--- a/static/scripts/modules/export.js
+++ b/static/scripts/modules/export.js
@@ -2,7 +2,11 @@ import * as Blockly from "blockly";
 import { resetHasUnsavedChangesHandling } from "./unsavedChangesHandling";
 import { workspace, getCode } from "./blocklyHandling";
 import { logDB } from "./logging";
-import { saveFileBrowser as saveFile, copyToClipboard, readFile } from "./fileUtils";
+import {
+  saveFileBrowser as saveFile,
+  copyToClipboard,
+  readFile,
+} from "./fileUtils";
 import JSZip from "../jszip";
 
 function copyXMLToClipboard() {
@@ -119,7 +123,7 @@ async function prepare_csvhandler() {
   // rename fileUtils.js to fileUtils.mjs
   importFileUtils = lines.shift();
   importFileUtils = importFileUtils.replace(".js", ".mjs");
-  code = importFileUtils + lines.join("\n");
+  code = importFileUtils + "\n" + lines.join("\n");
   return code;
 }
 

--- a/static/scripts/modules/export.js
+++ b/static/scripts/modules/export.js
@@ -32,7 +32,7 @@ async function downloadWorkspaceAsJS() {
   let csv_handler = prepare_csvhandler();
   let readme = await readFile("./export/README.md");
   let main = await readFile("./export/main.mjs");
-  let logging = await readFile("./scripts/modules/logging.js");
+  let logging = await prepare_logging();
   let jszip = await readFile("./scripts/jszip.js");
   let fileutils = await prepare_fileUtils();
   // Check if everything worked out
@@ -113,16 +113,14 @@ function prepare_algorithm() {
 }
 
 async function prepare_csvhandler() {
-  let file, lines, code, importFileUtils;
+  let file, lines, code;
   if (!(file = await readFile("./scripts/CSVHandler.js"))) return false;
-
-  lines = file.split("\n");
   // remove importstatement of workspace.js
+  lines = file.split("\n");
   lines.shift();
-  // rename fileUtils.js to fileUtils.mjs
-  importFileUtils = lines.shift();
-  importFileUtils = importFileUtils.replace(".js", ".mjs");
-  code = importFileUtils + "\n" + lines.join("\n");
+  code = lines.join("\n");
+  // rename fileUtils to fileUtils.mjs
+  code = code.replace("/fileUtils", "/fileUtils.mjs");
   return code;
 }
 
@@ -132,6 +130,14 @@ async function prepare_fileUtils() {
   if (!(file = await readFile("./scripts/modules/fileUtils.js"))) return false;
   let code = `import fs from "fs";\n`;
   code += file;
+  return code;
+}
+
+async function prepare_logging() {
+  let file, code;
+  if (!(file = await readFile("./scripts/modules/logging.js"))) return false;
+  // rename fileUtils to fileUtils.mjs
+  code = file.replace("/fileUtils", "/fileUtils.mjs");
   return code;
 }
 

--- a/static/scripts/modules/export.js
+++ b/static/scripts/modules/export.js
@@ -51,7 +51,7 @@ async function downloadWorkspaceAsJS() {
   zip.file("logging.mjs", logging);
   zip.file("jszip.js", jszip);
   zip.folder("modules");
-  zip.file("modules/fileUtils.js", fileutils);
+  zip.file("modules/fileUtils.mjs", fileutils);
   let zip_file = await zip.generateAsync({ type: "blob" });
   downloadFile(zip_file, "elea.zip");
 }
@@ -110,10 +110,18 @@ function prepare_algorithm() {
 }
 
 async function prepare_csvhandler() {
-  // Import fs for the node env
-  let file;
+  let file, lines, code, importFileUtils;
   if (!(file = await readFile("./scripts/CSVHandler.js"))) return false;
-  let code = `import fs from "fs";\n`;
+
+  lines = file.split("\n");
+  // remove importstatement of workspace.js
+  lines.shift();
+  // rename fileUtils.js to fileUtils.mjs
+  importFileUtils = lines.shift();
+  importFileUtils = importFileUtils.replace(".js", ".mjs");
+  file = importFileUtils + lines.join("\n");
+  // Import fs for the node env
+  code = `import fs from "fs";\n`;
   code += file;
   return code;
 }

--- a/static/scripts/modules/logging.js
+++ b/static/scripts/modules/logging.js
@@ -1,4 +1,4 @@
-import { saveFileBrowser as saveFile } from "./fileUtils";
+import { saveFileBrowser, saveFileNode } from "./fileUtils";
 import JSZip from "../jszip.js";
 
 var logDB = {};
@@ -113,13 +113,11 @@ async function downloadLog() {
   if (!globalThis.window) {
     zip.generateAsync({ type: "nodebuffer" }).then(function (content) {
       //eslint-disable-next-line no-undef -- is imported in nodejs env
-      fs.writeFile(FILE_NAME, content, function (e) {
-        if (e) return console.error(e);
-      });
+      saveFileNode(content, FILE_NAME);
     });
   } else {
     let file = await zip.generateAsync({ type: "blob" });
-    saveFile(file, FILE_NAME);
+    saveFileBrowser(file, FILE_NAME);
   }
 }
 


### PR DESCRIPTION
I fixed the import behavior of the CSVHandler in a node environment. It imported workspace, which is not available in the environment. Furthermore, fileUtils should be a .mjs file to work correctly in the node environment. 
I edited the export-preparation function of the CSVHandler to remove the line with the workspace import and replace `.js` with `.mjs` in the import statement of fileUtils.