### PR TITLE
Don't download CSV if it's empty

### DIFF
--- a/static/export/main.mjs
+++ b/static/export/main.mjs
@@ -1,5 +1,5 @@
 import {handleLogFromWorker} from "./logging.mjs";
-import { downloadCSV, updateValue } from "./CSVHandler.mjs";
+import { downloadCSV, updateValue, hasCSVEntries } from "./CSVHandler.mjs";
 import { Worker }  from "worker_threads";
 var worker = new Worker("./algorithm.js");
 worker.on("message", handleMessageFromWorker);
@@ -40,7 +40,8 @@ function handleErrorFromWorker(err){
 function terminateWorker(){
     if (worker != null) {
         worker.terminate();
-        downloadCSV();
+        if(hasCSVEntries())
+            downloadCSV();
         console.warn("Terminated running worker");
     }
 }

--- a/static/scripts/CSVHandler.js
+++ b/static/scripts/CSVHandler.js
@@ -52,6 +52,10 @@ class CSVHandler {
     );
     this.print("You can download the files at 'Save/Restore Algorithm'");
   }
+
+  hasCSVEntries() {
+    return this.csvMap.size != 0;
+  }
 }
 
 class CSVWorker {
@@ -142,4 +146,8 @@ function printDoneMessage() {
   csvHandler.printDoneMessage();
 }
 
-export { updateValue, downloadCSV, clearCSV, printDoneMessage };
+function hasCSVEntries() {
+  return csvHandler.hasCSVEntries();
+}
+
+export { updateValue, downloadCSV, clearCSV, printDoneMessage, hasCSVEntries };

--- a/static/scripts/workspace.js
+++ b/static/scripts/workspace.js
@@ -10,7 +10,7 @@ import { downloadLog } from "./modules/export";
 import { highlightAll } from "prismjs";
 import $ from "jquery";
 import { clearPlots } from "./PlotHandler";
-import { clearCSV, downloadCSV } from "./CSVHandler";
+import { clearCSV, downloadCSV, hasCSVEntries } from "./CSVHandler";
 
 $("#run-button").click(runCode);
 $("#kill-button").click(terminateWorker);
@@ -43,7 +43,7 @@ $("#copy_xml").click(copyXMLToClipboard);
 $("#download_js").click(downloadWorkspaceAsJS);
 $("#show_js").click(highlightAll);
 $("#download_json").click(downloadLog);
-$("#download_csv").click(downloadCSV);
+$("#download_csv").click(tryDownloadCSV);
 
 // Align the output column to the height of the workspace
 $("#output-column").height($("#blockly-div").height());
@@ -104,6 +104,14 @@ function addNewOutputEntry(outputContent, outputContentID, title) {
     $(`#output-${numOutput}-content`).slideToggle(300);
   });
   return document.getElementById(outputContentID);
+}
+
+function tryDownloadCSV() {
+  if (hasCSVEntries()) downloadCSV();
+  else
+    alert(
+      "The CSV file is empty. Use the CSV-Block in logging to save data in it."
+    );
 }
 
 export { addPrintOutput, addNewOutputEntry };


### PR DESCRIPTION
I added the functionality that the application doesn't download the CSV file if it's empty. It's confusing if you run the exported project and it generates an empty zip file that would contain CSV files if they weren't empty - likewise, the button "downloadCSV" in the workspace. 

I introduced a query `hasCSVEntries` that the workspace and the exported project can use to verify that generating the CSV file is meaningful.