### PR TITLE
Use links in footer for Netlify and Blockly

### DIFF
--- a/static/documentation.html
+++ b/static/documentation.html
@@ -290,7 +290,12 @@
       </div>
     </main>
     <footer>
-      <p>Project ELEA 💚 Build with Netlify and Blockly</p>
+      <p>
+        Project ELEA 💚 This site is powered by
+        <a href="https://www.netlify.com/">Netlify</a>
+        and
+        <a href="https://developers.google.com/blockly">Blockly</a>
+      </p>
       <p>
         <a href="https://github.com/HPI-ELEA/elea">Github</a>
         •

--- a/static/faq.html
+++ b/static/faq.html
@@ -160,7 +160,12 @@
       </div>
     </main>
     <footer>
-      <p>Project ELEA 💚 Build with Netlify and Blockly</p>
+      <p>
+        Project ELEA 💚 This site is powered by
+        <a href="https://www.netlify.com/">Netlify</a>
+        and
+        <a href="https://developers.google.com/blockly">Blockly</a>
+      </p>
       <p>
         <a href="https://github.com/HPI-ELEA/elea">Github</a>
         •

--- a/static/index.html
+++ b/static/index.html
@@ -187,7 +187,12 @@
       </div>
     </main>
     <footer>
-      <p>Project ELEA 💚 Build with Netlify and Blockly</p>
+      <p>
+        Project ELEA 💚 This site is powered by
+        <a href="https://www.netlify.com/">Netlify</a>
+        and
+        <a href="https://developers.google.com/blockly">Blockly</a>
+      </p>
       <p>
         <a href="https://github.com/HPI-ELEA/elea">Github</a>
         •

--- a/static/legal.html
+++ b/static/legal.html
@@ -137,7 +137,12 @@
       </div>
     </main>
     <footer>
-      <p>Project ELEA 💚 Build with Netlify and Blockly</p>
+      <p>
+        Project ELEA 💚 This site is powered by
+        <a href="https://www.netlify.com/">Netlify</a>
+        and
+        <a href="https://developers.google.com/blockly">Blockly</a>
+      </p>
       <p>
         <a href="https://github.com/HPI-ELEA/elea">Github</a>
         •

--- a/static/privacy.html
+++ b/static/privacy.html
@@ -521,7 +521,12 @@
       </div>
     </main>
     <footer>
-      <p>Project ELEA 💚 Build with Netlify and Blockly</p>
+      <p>
+        Project ELEA 💚 This site is powered by
+        <a href="https://www.netlify.com/">Netlify</a>
+        and
+        <a href="https://developers.google.com/blockly">Blockly</a>
+      </p>
       <p>
         <a href="https://github.com/HPI-ELEA/elea">Github</a>
         •

--- a/static/workspace.html
+++ b/static/workspace.html
@@ -231,7 +231,12 @@
       </p>
     </main>
     <footer>
-      <p>Project ELEA 💚 Build with Netlify and Blockly</p>
+      <p>
+        Project ELEA 💚 This site is powered by
+        <a href="https://www.netlify.com/">Netlify</a>
+        and
+        <a href="https://developers.google.com/blockly">Blockly</a>
+      </p>
       <p>
         <a href="https://github.com/HPI-ELEA/elea">Github</a>
         •


### PR DESCRIPTION
To get the open source plan of netlify, our website has to contain a link to their service and it should read This site is powered by Netlify.