### PR TITLE
Fix missing IOHAnalyzerHandler in exported project

### DIFF
--- a/static/export/main.mjs
+++ b/static/export/main.mjs
@@ -1,4 +1,4 @@
-import { handleLogFromWorker, downloadLog } from "./modules/logging.mjs";
+import { handleLogFromWorker, downloadLog } from "./modules/IOHAnalyzerHandler.mjs";
 import { downloadCSV, updateValue, hasCSVEntries } from "./CSVHandler.mjs";
 import { updateValue as updatePlotValue, drawPlots } from "./PlotHandler.mjs";
 import { Worker }  from "worker_threads";


### PR DESCRIPTION
This RP edits the import statement in `main.mjs` that the exported project imports the IOHAnalyzerHandler correctly.