### PR TITLE
Align naming of IOHAnalyzerHandler and CSVHandler 

### DIFF
--- a/static/export/main.mjs
+++ b/static/export/main.mjs
@@ -1,5 +1,5 @@
-import { handleLogFromWorker, downloadLog } from "./modules/logging.mjs";
-import { downloadCSV, updateValue, hasCSVEntries } from "./CSVHandler.mjs";
+import { updateValueIOH, downloadIOH } from "./modules/IOHAnalyzerHandler.mjs";
+import { downloadCSV, updateValueCSV, hasEntriesCSV } from "./CSVHandler.mjs";
 import { updateValue as updatePlotValue, drawPlots } from "./PlotHandler.mjs";
 import { Worker }  from "worker_threads";
 var worker = new Worker("./algorithm.js");
@@ -15,12 +15,12 @@ function handleMessageFromWorker(msg){
     }
 
     if (msg.ctrl == "log") {
-        handleLogFromWorker(msg.data);
+        updateValueIOH(msg.data);
         return;
     }
 
     if(msg.ctrl == "csv") {
-        updateValue(msg.data);
+        updateValueCSV(msg.data);
         return;
     }
 
@@ -46,9 +46,9 @@ function handleErrorFromWorker(err){
 function terminateWorker(){
     if (worker != null) {
         worker.terminate();
-        if(hasCSVEntries())
+        if(hasEntriesCSV())
             downloadCSV();
-        downloadLog();
+        downloadIOH();
         drawPlots(); 
         console.warn("Terminated running worker");
     }

--- a/static/scripts/CSVHandler.js
+++ b/static/scripts/CSVHandler.js
@@ -35,13 +35,13 @@ class CSVHandler {
     requestedCSV.updateValue(data);
   }
 
-  async downloadCSV() {
+  async download() {
     let zip = JSZip();
     this.csvMap.forEach((value) => value.downloadCSV(zip));
     await downloadZIP(zip, "elea.zip");
   }
 
-  clearCSV() {
+  clear() {
     this.csvMap = new Map();
   }
 
@@ -53,7 +53,7 @@ class CSVHandler {
     this.print("You can download the files at 'Save/Restore Algorithm'");
   }
 
-  hasCSVEntries() {
+  hasEntries() {
     return this.csvMap.size != 0;
   }
 }
@@ -127,24 +127,30 @@ async function downloadZIP(zip) {
 
 var csvHandler = new CSVHandler();
 
-function updateValue(data) {
+function updateValueCSV(data) {
   csvHandler.updateValue(data);
 }
 
 function downloadCSV() {
-  csvHandler.downloadCSV();
+  csvHandler.download();
 }
 
 function clearCSV() {
-  csvHandler.clearCSV();
+  csvHandler.clear();
 }
 
-function printDoneMessage() {
+function printDoneMessageCSV() {
   csvHandler.printDoneMessage();
 }
 
-function hasCSVEntries() {
-  return csvHandler.hasCSVEntries();
+function hasEntriesCSV() {
+  return csvHandler.hasEntries();
 }
 
-export { updateValue, downloadCSV, clearCSV, printDoneMessage, hasCSVEntries };
+export {
+  updateValueCSV,
+  downloadCSV,
+  clearCSV,
+  printDoneMessageCSV,
+  hasEntriesCSV,
+};

--- a/static/scripts/modules/IOHAnalyzerHandler.js
+++ b/static/scripts/modules/IOHAnalyzerHandler.js
@@ -130,20 +130,20 @@ function zipAlgorithm(zip, db, algorithm) {
 
 var iohHandler = new IOHAnalyzerHandler();
 
-function handleLogFromWorker(data) {
+function updateValueIOH(data) {
   iohHandler.updateValue(data);
 }
 
-function downloadLog() {
+function downloadIOH() {
   iohHandler.download();
 }
 
-function clearLog() {
+function clearIOH() {
   iohHandler.clear();
 }
 
-function hasLogEntries() {
+function hasEntriesIOH() {
   return iohHandler.hasEntries();
 }
 
-export { clearLog, handleLogFromWorker, downloadLog, hasLogEntries };
+export { clearIOH, updateValueIOH, downloadIOH, hasEntriesIOH };

--- a/static/scripts/modules/blocklyHandling.js
+++ b/static/scripts/modules/blocklyHandling.js
@@ -3,12 +3,12 @@ var USING_THREADS = false;
 import * as Blockly from "blockly";
 import beautify from "js-beautify";
 import "regenerator-runtime/runtime";
-import { clearLog, handleLogFromWorker } from "./IOHAnalyzerHandler";
+import { clearIOH, updateValueIOH } from "./IOHAnalyzerHandler";
 import "../normalBlockBehaviour";
 import "../threadBlockBehaviour";
 import { addPrintOutput } from "../workspace";
 import { updateValue as updateValuePlot, drawPlots } from "../PlotHandler";
-import { updateValue as updateValueCSV, printDoneMessage } from "../CSVHandler";
+import { updateValueCSV, printDoneMessageCSV } from "../CSVHandler";
 import { theme } from "./blockTheme";
 
 // var jsonLog = null;
@@ -125,7 +125,7 @@ switch (msg.data.aTopic) {\
 }";
 
 function runCode() {
-  clearLog();
+  clearIOH();
   terminateWorker();
   Blockly.JavaScript.STATEMENT_PREFIX = "";
   //Blockly.JavaScript.addReservedWords('highlightBlock');
@@ -184,7 +184,7 @@ function handleMessageFromWorker(msg) {
   }
 
   if (msg.ctrl == "log") {
-    handleLogFromWorker(msg.data);
+    updateValueIOH(msg.data);
     return;
   }
 
@@ -202,7 +202,7 @@ function handleMessageFromWorker(msg) {
   if (msg.ctrl == "terminate") {
     console.log("terminate worker due to its request.");
     terminateWorker();
-    printDoneMessage();
+    printDoneMessageCSV();
     drawPlots();
     return;
   }

--- a/static/scripts/workspace.js
+++ b/static/scripts/workspace.js
@@ -7,11 +7,7 @@ import {
   downloadWorkspaceAsJS,
 } from "./modules/export";
 import { downloadIOH, hasEntriesIOH } from "./modules/IOHAnalyzerHandler";
-import {
-  clearLog,
-  downloadLog,
-  hasLogEntries,
-} from "./modules/IOHAnalyzerHandler";
+import { clearLog } from "./modules/IOHAnalyzerHandler";
 import { highlightAll } from "prismjs";
 import $ from "jquery";
 import { clearPlots } from "./PlotHandler";

--- a/static/scripts/workspace.js
+++ b/static/scripts/workspace.js
@@ -6,11 +6,11 @@ import {
   downloadWorkspace,
   downloadWorkspaceAsJS,
 } from "./modules/export";
-import { downloadLog, hasLogEntries } from "./modules/IOHAnalyzerHandler";
+import { downloadIOH, hasEntriesIOH } from "./modules/IOHAnalyzerHandler";
 import { highlightAll } from "prismjs";
 import $ from "jquery";
 import { clearPlots } from "./PlotHandler";
-import { clearCSV, downloadCSV, hasCSVEntries } from "./CSVHandler";
+import { clearCSV, downloadCSV, hasEntriesCSV } from "./CSVHandler";
 
 $("#run-button").click(runCode);
 $("#kill-button").click(terminateWorker);
@@ -107,7 +107,7 @@ function addNewOutputEntry(outputContent, outputContentID, title) {
 }
 
 function tryDownloadCSV() {
-  if (hasCSVEntries()) downloadCSV();
+  if (hasEntriesCSV()) downloadCSV();
   else
     alert(
       "The CSV file is empty. Use the CSV-Block in logging to save data in it."
@@ -115,7 +115,7 @@ function tryDownloadCSV() {
 }
 
 function tryDownloadLog() {
-  if (hasLogEntries()) downloadLog();
+  if (hasEntriesIOH()) downloadIOH();
   else alert("The IOHAnalyzer file is empty.");
 }
 


### PR DESCRIPTION
This PR aligns the naming of the IOHAnalyzerHandler and CSVHandler to make the architecture more understandable. I did this by renaming the class functions to `updateValue`, `clear`, `hasEntries`, and `download`. The singleton functions have the suffix `CSV` or `IOH`.