### PR TITLE
[indivDeleteOutputEntry] Remove single plot

### DIFF
--- a/static/scripts/PlotHandler.js
+++ b/static/scripts/PlotHandler.js
@@ -10,7 +10,7 @@ class PlotHandler {
     let plotName = data.plotName;
     let requestedPlot = this.plotMap.get(plotName);
     if (!requestedPlot) {
-      requestedPlot = new PlotWorker(plotName);
+      requestedPlot = new PlotWorker(plotName, this);
       this.plotMap.set(plotName, requestedPlot);
     }
     requestedPlot.updateValue(data);
@@ -30,11 +30,16 @@ class PlotHandler {
   clearPlots() {
     this.plotMap = new Map();
   }
+
+  removePlot(plotName) {
+    this.plotMap.delete(plotName);
+  }
 }
 
 class PlotWorker {
-  constructor(name) {
+  constructor(name, plotHandler) {
     this.plotName = name;
+    this.plotHandler = plotHandler;
     this.plotData = new Map();
     this.myChart = null;
     this.chartExists = false;


### PR DESCRIPTION
This PR adds a reference from PlotWorker to PlotHandler that lets the PlotWorker remove itself. In future PR this will help to introduce deletable output entries.