### PR TITLE
Create consistency of downloaded files in exported project

### DIFF
--- a/static/export/main.mjs
+++ b/static/export/main.mjs
@@ -40,7 +40,10 @@ function handleMessageFromWorker(msg){
 
 function handleErrorFromWorker(err){
     terminateWorker()
-    downloadCSV();
+    if(hasCSVEntries())
+            downloadCSV();
+    if(hasLogEntries())
+        downloadLog();
     throw new Error(err.stack)
 }
 

--- a/static/export/main.mjs
+++ b/static/export/main.mjs
@@ -2,6 +2,7 @@ import { handleLogFromWorker, downloadLog } from "./modules/logging.mjs";
 import { downloadCSV, updateValue, hasCSVEntries } from "./CSVHandler.mjs";
 import { updateValue as updatePlotValue, drawPlots } from "./PlotHandler.mjs";
 import { Worker }  from "worker_threads";
+import { hasLogEntries } from "../scripts/modules/IOHAnalyzerHandler.js";
 var worker = new Worker("./algorithm.js");
 worker.on("message", handleMessageFromWorker);
 worker.on("error", handleErrorFromWorker);
@@ -48,7 +49,8 @@ function terminateWorker(){
         worker.terminate();
         if(hasCSVEntries())
             downloadCSV();
-        downloadLog();
+        if(hasLogEntries())
+            downloadLog();
         drawPlots(); 
         console.warn("Terminated running worker");
     }

--- a/static/export/main.mjs
+++ b/static/export/main.mjs
@@ -2,7 +2,7 @@ import { handleLogFromWorker, downloadLog } from "./modules/logging.mjs";
 import { downloadCSV, updateValue, hasCSVEntries } from "./CSVHandler.mjs";
 import { updateValue as updatePlotValue, drawPlots } from "./PlotHandler.mjs";
 import { Worker }  from "worker_threads";
-import { hasLogEntries } from "../scripts/modules/IOHAnalyzerHandler.js";
+import { hasLogEntries } from "../scripts/modules/IOHAnalyzerHandler.mjs";
 var worker = new Worker("./algorithm.js");
 worker.on("message", handleMessageFromWorker);
 worker.on("error", handleErrorFromWorker);


### PR DESCRIPTION
With this PR files are only downloaded in the exported project when necessary. Now the user doesn't have useless empty files generated anymore.