### PR TITLE
Delete print after clearing CSV

### DIFF
--- a/static/scripts/CSVHandler.js
+++ b/static/scripts/CSVHandler.js
@@ -43,6 +43,7 @@ class CSVHandler {
 
   clearCSV() {
     this.csvMap = new Map();
+    this.print = null;
   }
 
   printDoneMessage() {


### PR DESCRIPTION
After clearing the CSVHandler, it now removes the internal printing function because the clearing process removes the output entry too.