### PR TITLE
Fix no printing in threads

### DIFF
--- a/static/scripts/MessageHandler.js
+++ b/static/scripts/MessageHandler.js
@@ -91,7 +91,7 @@ class MessageHandler {
     }
 
     // if the message is a log or a print statement then forward the message further up the chain
-    if (message.ctrl in ["log", "print", "plot", "csv"]) {
+    if (["log", "print", "plot", "csv"].some((m) => m == message.ctrl)) {
       this.sendMessage(message);
       return;
     }


### PR DESCRIPTION
At the moment, it's not possible to send messages with `print`, `plot`, `log` or `csv` from a thread to its parent. The reason is the usage of the wrong syntax in the MessageHandler, which I fixed now.