### PR TITLE
Change multithreading to use async/await

### DIFF
--- a/static/scripts/normalBlockBehaviour.js
+++ b/static/scripts/normalBlockBehaviour.js
@@ -45,18 +45,12 @@ Blockly.JavaScript["ea_init"] = function (block) {
   );
 
   let code = "";
-  code = "function* mainFunction() {\n\n";
-  code += "try {\n";
+  code = "async function mainFunction() {\n";
   code += statementsSimulationSteps;
-  code += "} catch(e) {\n";
-  code += "    consoleerror(e);\n";
-  code += "} finally {\n";
-  code +=
-    '  Handler.sendMessage(new Message(Handler.PARENT_ID, 0, "terminate"));\n';
-  code += "};\n";
   code += "}\n";
-  code += "globalThis.main = mainFunction();\n";
-  code += "globalThis.main.next();\n";
+  code += "mainFunction()\n";
+  code += ".catch( error => console.error(error) )\n";
+  code += ".finally( () => Handler.sendMessage(new Message(Handler.PARENT_ID, 0, 'terminate')) );\n";
   return code;
 };
 


### PR DESCRIPTION
Uses promises instead of generators.
This is much more readable than the old approach and is easier to
expand with more features.

Opens up the ability to place thread blocks in function blocks, which
I experimented with [here](https://github.com/HPI-ELEA/elea/compare/main...async-await).

I've been thinking for a while about some of the decisions I made
with this multithreading system that I regret, and the main thing
was not using promises, so I decided to implement it in my free time.
You can choose whether or not you'd like to merge this.
I haven't looking into what changes would need to be
made to the documentation yet.