### PR TITLE
Migrate to bootstrap 5.2 and implement offcanvas

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
       "name": "elea",
       "dependencies": {
         "blockly": "^6.20210701.0",
-        "bootstrap": "^4.6.1",
+        "bootstrap": "^5.2.0-beta1",
         "chart.js": "^3.8.0",
         "d3": "^7.5.0",
         "jquery": "^3.6.0",
@@ -1969,6 +1969,16 @@
         "node": ">= 6.0.0"
       }
     },
+    "node_modules/@popperjs/core": {
+      "version": "2.11.5",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.5.tgz",
+      "integrity": "sha512-9X2obfABZuDVLCgPK9aX0a/x4jaOEweTTWE2+9sr0Qqqevj2Uv5XorvusThmc9XGYpS9yI+fhh8RTafBtGposw==",
+      "peer": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/popperjs"
+      }
+    },
     "node_modules/@types/eslint-visitor-keys": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
@@ -2824,16 +2834,21 @@
       "dev": true
     },
     "node_modules/bootstrap": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.6.1.tgz",
-      "integrity": "sha512-0dj+VgI9Ecom+rvvpNZ4MUZJz8dcX7WCX+eTID9+/8HgOkv3dsRzi8BGeZJCQU6flWQVYxwTQnEZFrmJSEO7og==",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/bootstrap"
-      },
+      "version": "5.2.0-beta1",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.2.0-beta1.tgz",
+      "integrity": "sha512-6qbgs177WZEFY4SLQUq3tEHayYG80nfDmyTpdKi0MJqRMdS+HAoq24+YKfx6wf+nHY0rx8zrh477J1lFu4WzOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/twbs"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/bootstrap"
+        }
+      ],
       "peerDependencies": {
-        "jquery": "1.9.1 - 3",
-        "popper.js": "^1.16.1"
+        "@popperjs/core": "^2.11.5"
       }
     },
     "node_modules/brace-expansion": {
@@ -3124,14 +3139,20 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001282",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001282.tgz",
-      "integrity": "sha512-YhF/hG6nqBEllymSIjLtR2iWDDnChvhnVJqp+vloyt2tEHFG1yBR+ac2B/rOw0qOK0m0lEXU2dv4E/sMk5P9Kg==",
+      "version": "1.0.30001367",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001367.tgz",
+      "integrity": "sha512-XDgbeOHfifWV3GEES2B8rtsrADx4Jf+juKX2SICJcaUhjYBO3bR96kvEIHa15VU6ohtOhBZuPGGYGbXMRn0NCw==",
       "dev": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/browserslist"
-      }
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        }
+      ]
     },
     "node_modules/caseless": {
       "version": "0.12.0",
@@ -8522,17 +8543,6 @@
       "version": "1.1.0",
       "integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA=="
     },
-    "node_modules/popper.js": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
-      "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==",
-      "deprecated": "You can find the new Popper v2 at @popperjs/core, this package is dedicated to the legacy v1",
-      "peer": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/popperjs"
-      }
-    },
     "node_modules/posix-character-classes": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
@@ -13708,6 +13718,12 @@
         "physical-cpu-count": "^2.0.0"
       }
     },
+    "@popperjs/core": {
+      "version": "2.11.5",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.5.tgz",
+      "integrity": "sha512-9X2obfABZuDVLCgPK9aX0a/x4jaOEweTTWE2+9sr0Qqqevj2Uv5XorvusThmc9XGYpS9yI+fhh8RTafBtGposw==",
+      "peer": true
+    },
     "@types/eslint-visitor-keys": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
@@ -14379,9 +14395,9 @@
       "dev": true
     },
     "bootstrap": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.6.1.tgz",
-      "integrity": "sha512-0dj+VgI9Ecom+rvvpNZ4MUZJz8dcX7WCX+eTID9+/8HgOkv3dsRzi8BGeZJCQU6flWQVYxwTQnEZFrmJSEO7og==",
+      "version": "5.2.0-beta1",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.2.0-beta1.tgz",
+      "integrity": "sha512-6qbgs177WZEFY4SLQUq3tEHayYG80nfDmyTpdKi0MJqRMdS+HAoq24+YKfx6wf+nHY0rx8zrh477J1lFu4WzOA==",
       "requires": {}
     },
     "brace-expansion": {
@@ -14637,9 +14653,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001282",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001282.tgz",
-      "integrity": "sha512-YhF/hG6nqBEllymSIjLtR2iWDDnChvhnVJqp+vloyt2tEHFG1yBR+ac2B/rOw0qOK0m0lEXU2dv4E/sMk5P9Kg==",
+      "version": "1.0.30001367",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001367.tgz",
+      "integrity": "sha512-XDgbeOHfifWV3GEES2B8rtsrADx4Jf+juKX2SICJcaUhjYBO3bR96kvEIHa15VU6ohtOhBZuPGGYGbXMRn0NCw==",
       "dev": true
     },
     "caseless": {
@@ -18905,12 +18921,6 @@
     "pn": {
       "version": "1.1.0",
       "integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA=="
-    },
-    "popper.js": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
-      "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==",
-      "peer": true
     },
     "posix-character-classes": {
       "version": "0.1.1",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "blockly": "^6.20210701.0",
-    "bootstrap": "^4.6.1",
+    "bootstrap": "^5.2.0-beta1",
     "chart.js": "^3.8.0",
     "d3": "^7.5.0",
     "jquery": "^3.6.0",

--- a/static/css/documentation.css
+++ b/static/css/documentation.css
@@ -30,3 +30,6 @@
 #intoduction-category-list > li > a {
   color: #0c5460 !important;
 }
+.display-5 p {
+  font-size: large;
+}

--- a/static/css/globals.css
+++ b/static/css/globals.css
@@ -40,3 +40,7 @@ p > a {
   justify-content: center;
   align-items: center;
 }
+
+#jumbotron {
+  margin-bottom: 10px;
+}

--- a/static/css/workspace.css
+++ b/static/css/workspace.css
@@ -6,7 +6,6 @@ main {
 }
 
 #workspace-header {
-  padding-top: 4rem;
   flex: 0 1 auto;
   display: flex;
   flex-direction: row;

--- a/static/documentation.html
+++ b/static/documentation.html
@@ -113,7 +113,7 @@
       </div>
     </nav>
     <main>
-      <div class="jumbotron">
+      <div class="container-fluid bg-dark text-white p-5" id="jumbotron">
         <div class="container">
           <h1 class="display-3">Documentation</h1>
         </div>

--- a/static/documentation.html
+++ b/static/documentation.html
@@ -21,95 +21,122 @@
 
   <body>
     <nav class="navbar navbar-expand-lg navbar-light bg-light">
-      <a class="navbar-brand" href="index.html">
-        <img
-          src="favicon.svg"
-          alt="elea-logo"
-          width="30rem"
-          height="30rem"
-          class="d-inline-block align-top"
-        />
-        Build Your Own EA
-      </a>
-      <button
-        class="navbar-toggler"
-        type="button"
-        data-toggle="collapse"
-        data-target="#navbarSupportedContent"
-        aria-controls="navbarSupportedContent"
-        aria-expanded="false"
-        aria-label="Toggle navigation"
-      >
-        <span class="navbar-toggler-icon"></span>
-      </button>
-
-      <div class="collapse navbar-collapse" id="navbarSupportedContent">
-        <ul class="navbar-nav mr-auto">
-          <li class="nav-item">
-            <a class="nav-link" href="workspace.html?example=full">
-              Demo
-              <span class="sr-only">(current)</span>
-            </a>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link" target="_blank" href="faq.html">FAQ</a>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link" target="_blank" href="documentation.html">
-              Documentation
-            </a>
-          </li>
-          <li class="nav-item dropdown">
-            <a
-              class="nav-link dropdown-toggle"
-              href="#"
-              id="navbarExampleDropdown"
-              role="button"
-              data-toggle="dropdown"
-              aria-haspopup="true"
-              aria-expanded="false"
+      <div class="container-fluid">
+        <a class="navbar-brand" href="index.html">
+          <img
+            src="favicon.svg"
+            alt="elea-logo"
+            width="30rem"
+            height="30rem"
+            class="d-inline-block align-top"
+          />
+          Build Your Own EA
+        </a>
+        <button 
+            class="navbar-toggler" 
+            type="button" 
+            data-bs-toggle="offcanvas" 
+            data-bs-target="#navbarOffcanvasLg" 
+            aria-controls="navbarOffcanvasLg"
+            aria-expanded="false"
+            aria-label="Toggle navigation"
             >
-              Examples
-            </a>
-            <div class="dropdown-menu" aria-labelledby="navbarExampleDropdown">
-              <a class="dropdown-item" href="workspace.html?example=empty">
-                Empty starting point
-              </a>
-              <div class="dropdown-divider"></div>
-              <a class="dropdown-item" href="workspace.html?example=full">
-                Full example
-              </a>
-              <a class="dropdown-item" href="workspace.html?example=simple">
-                Simple example
-              </a>
-              <div class="dropdown-divider"></div>
-              <a class="dropdown-item" href="workspace.html?example=oneplusone">
-                1+1
-              </a>
-              <a class="dropdown-item" href="#">1+λ (TODO)</a>
-              <a class="dropdown-item" href="#">1,λ (TODO)</a>
-              <div class="dropdown-divider"></div>
-              <a
-                class="dropdown-item"
-                href="workspace.html?example=multithread"
-              >
-                Multi-Threading Example
-              </a>
-              <a
-                class="dropdown-item"
-                href="workspace.html?example=full_multithread"
-              >
-                Full example with Muti-Threading
-              </a>
-              <a
-                class="dropdown-item"
-                href="workspace.html?example=multithread-performance"
-              >
-                Muti-Threading Performance Test
-              </a>
-            </div>
-          </li>
-        </ul>
+          <span class="navbar-toggler-icon"></span>
+        </button>
+  
+        <div class="offcanvas offcanvas-end" tabindex="-1" id="navbarOffcanvasLg" aria-labelledby="navbarOffcanvasLgLabel">
+          <div class="offcanvas-header">
+            <h5 class="offcanvas-title" id="offcanvasNavbarLabel">Build Your Own EA</h5>
+            <button
+              type="button"
+              class="btn-close"
+              data-bs-dismiss="offcanvas"
+              aria-label="Close"
+            ></button>
+          </div>
+          <div class="offcanvas-body">
+            <ul class="navbar-nav mr-auto">
+              <li class="nav-item">
+                <a class="nav-link" href="workspace.html?example=full">
+                  Demo
+                  <span class="sr-only">(current)</span>
+                </a>
+              </li>
+              <li class="nav-item">
+                <a class="nav-link" href="faq.html">FAQ</a>
+              </li>
+              <li class="nav-item">
+                <a class="nav-link" href="documentation.html">Documentation</a>
+              </li>
+              <li class="nav-item dropdown">
+                <a
+                  class="nav-link dropdown-toggle"
+                  href="#"
+                  id="navbarExampleDropdown"
+                  role="button"
+                  data-bs-toggle="dropdown"
+                  aria-haspopup="true"
+                  aria-expanded="false"
+                >
+                  Examples
+                </a>
+                <ul
+                  class="dropdown-menu"
+                  aria-labelledby="navbarExampleDropdown"
+                >
+                  <li><a class="dropdown-item" href="workspace.html?example=empty">
+                    Empty starting point
+                  </a></li>
+                  <li><hr class="dropdown-divider"></li>
+                  <li><a class="dropdown-item" href="workspace.html?example=full">
+                    Full example
+                  </a></li>
+                  <li><a class="dropdown-item" href="workspace.html?example=simple">
+                    Simple example
+                  </a></li>
+                  <li><hr class="dropdown-divider"></li>
+                  <li><a
+                    class="dropdown-item"
+                    href="workspace.html?example=oneplusone"
+                  >
+                    1+1
+                  </a></li>
+                  <li><a
+                    class="dropdown-item"
+                    href="workspace.html?example=onepluslambda"
+                  >
+                    1+λ
+                  </a></li>
+                  <li><a
+                    class="dropdown-item"
+                    href="workspace.html?example=onelambda"
+                  >
+                    1,λ
+                  </a></li>
+                  <li><hr class="dropdown-divider"></li>
+                  <li><a
+                    class="dropdown-item"
+                    href="workspace.html?example=multithread"
+                  >
+                    Multi-Threading Example
+                  </a></li>
+                  <li><a
+                    class="dropdown-item"
+                    href="workspace.html?example=full_multithread"
+                  >
+                    Full example with Multi-Threading
+                  </a></li>
+                  <li><a
+                    class="dropdown-item"
+                    href="workspace.html?example=multithread-performance"
+                  >
+                    Multi-Threading Performance Test
+                  </a></li>
+                </ul>
+              </li>
+            </ul>
+          </div>
+        </div>
       </div>
     </nav>
     <main>

--- a/static/faq.html
+++ b/static/faq.html
@@ -112,7 +112,7 @@
       </div>
     </nav>
     <main>
-      <div class="jumbotron">
+      <div class="container-fluid bg-dark text-white p-5" id="jumbotron">
         <div class="container">
           <h1 class="display-3">FAQ</h1>
         </div>

--- a/static/faq.html
+++ b/static/faq.html
@@ -20,95 +20,122 @@
 
   <body>
     <nav class="navbar navbar-expand-lg navbar-light bg-light">
-      <a class="navbar-brand" href="index.html">
-        <img
-          src="favicon.svg"
-          alt="elea-logo"
-          width="30rem"
-          height="30rem"
-          class="d-inline-block align-top"
-        />
-        Build Your Own EA
-      </a>
-      <button
-        class="navbar-toggler"
-        type="button"
-        data-toggle="collapse"
-        data-target="#navbarSupportedContent"
-        aria-controls="navbarSupportedContent"
-        aria-expanded="false"
-        aria-label="Toggle navigation"
-      >
-        <span class="navbar-toggler-icon"></span>
-      </button>
-
-      <div class="collapse navbar-collapse" id="navbarSupportedContent">
-        <ul class="navbar-nav mr-auto">
-          <li class="nav-item">
-            <a class="nav-link" href="workspace.html?example=full">
-              Demo
-              <span class="sr-only">(current)</span>
-            </a>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link" target="_blank" href="faq.html">FAQ</a>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link" target="_blank" href="documentation.html">
-              Documentation
-            </a>
-          </li>
-          <li class="nav-item dropdown">
-            <a
-              class="nav-link dropdown-toggle"
-              href="#"
-              id="navbarExampleDropdown"
-              role="button"
-              data-toggle="dropdown"
-              aria-haspopup="true"
-              aria-expanded="false"
+      <div class="container-fluid">
+        <a class="navbar-brand" href="index.html">
+          <img
+            src="favicon.svg"
+            alt="elea-logo"
+            width="30rem"
+            height="30rem"
+            class="d-inline-block align-top"
+          />
+          Build Your Own EA
+        </a>
+        <button 
+            class="navbar-toggler" 
+            type="button" 
+            data-bs-toggle="offcanvas" 
+            data-bs-target="#navbarOffcanvasLg" 
+            aria-controls="navbarOffcanvasLg"
+            aria-expanded="false"
+            aria-label="Toggle navigation"
             >
-              Examples
-            </a>
-            <div class="dropdown-menu" aria-labelledby="navbarExampleDropdown">
-              <a class="dropdown-item" href="workspace.html?example=empty">
-                Empty starting point
-              </a>
-              <div class="dropdown-divider"></div>
-              <a class="dropdown-item" href="workspace.html?example=fulll">
-                Full example
-              </a>
-              <a class="dropdown-item" href="workspace.html?example=simple">
-                Simple example
-              </a>
-              <div class="dropdown-divider"></div>
-              <a class="dropdown-item" href="workspace.html?example=oneplusone">
-                1+1
-              </a>
-              <a class="dropdown-item" href="#">1+λ (TODO)</a>
-              <a class="dropdown-item" href="#">1,λ (TODO)</a>
-              <div class="dropdown-divider"></div>
-              <a
-                class="dropdown-item"
-                href="workspace.html?example=multithread"
-              >
-                Multi-Threading Example
-              </a>
-              <a
-                class="dropdown-item"
-                href="workspace.html?example=full_multithread"
-              >
-                Full example with Muti-Threading
-              </a>
-              <a
-                class="dropdown-item"
-                href="workspace.html?example=multithread-performance"
-              >
-                Muti-Threading Performance Test
-              </a>
-            </div>
-          </li>
-        </ul>
+          <span class="navbar-toggler-icon"></span>
+        </button>
+  
+        <div class="offcanvas offcanvas-end" tabindex="-1" id="navbarOffcanvasLg" aria-labelledby="navbarOffcanvasLgLabel">
+          <div class="offcanvas-header">
+            <h5 class="offcanvas-title" id="offcanvasNavbarLabel">Build Your Own EA</h5>
+            <button
+              type="button"
+              class="btn-close"
+              data-bs-dismiss="offcanvas"
+              aria-label="Close"
+            ></button>
+          </div>
+          <div class="offcanvas-body">
+            <ul class="navbar-nav mr-auto">
+              <li class="nav-item">
+                <a class="nav-link" href="workspace.html?example=full">
+                  Demo
+                  <span class="sr-only">(current)</span>
+                </a>
+              </li>
+              <li class="nav-item">
+                <a class="nav-link" href="faq.html">FAQ</a>
+              </li>
+              <li class="nav-item">
+                <a class="nav-link" href="documentation.html">Documentation</a>
+              </li>
+              <li class="nav-item dropdown">
+                <a
+                  class="nav-link dropdown-toggle"
+                  href="#"
+                  id="navbarExampleDropdown"
+                  role="button"
+                  data-bs-toggle="dropdown"
+                  aria-haspopup="true"
+                  aria-expanded="false"
+                >
+                  Examples
+                </a>
+                <ul
+                  class="dropdown-menu"
+                  aria-labelledby="navbarExampleDropdown"
+                >
+                  <li><a class="dropdown-item" href="workspace.html?example=empty">
+                    Empty starting point
+                  </a></li>
+                  <li><hr class="dropdown-divider"></li>
+                  <li><a class="dropdown-item" href="workspace.html?example=full">
+                    Full example
+                  </a></li>
+                  <li><a class="dropdown-item" href="workspace.html?example=simple">
+                    Simple example
+                  </a></li>
+                  <li><hr class="dropdown-divider"></li>
+                  <li><a
+                    class="dropdown-item"
+                    href="workspace.html?example=oneplusone"
+                  >
+                    1+1
+                  </a></li>
+                  <li><a
+                    class="dropdown-item"
+                    href="workspace.html?example=onepluslambda"
+                  >
+                    1+λ
+                  </a></li>
+                  <li><a
+                    class="dropdown-item"
+                    href="workspace.html?example=onelambda"
+                  >
+                    1,λ
+                  </a></li>
+                  <li><hr class="dropdown-divider"></li>
+                  <li><a
+                    class="dropdown-item"
+                    href="workspace.html?example=multithread"
+                  >
+                    Multi-Threading Example
+                  </a></li>
+                  <li><a
+                    class="dropdown-item"
+                    href="workspace.html?example=full_multithread"
+                  >
+                    Full example with Multi-Threading
+                  </a></li>
+                  <li><a
+                    class="dropdown-item"
+                    href="workspace.html?example=multithread-performance"
+                  >
+                    Multi-Threading Performance Test
+                  </a></li>
+                </ul>
+              </li>
+            </ul>
+          </div>
+        </div>
       </div>
     </nav>
     <main>

--- a/static/index.html
+++ b/static/index.html
@@ -119,9 +119,9 @@
     </nav>
     <main role="main">
       <!-- Main jumbotron for a primary marketing message or call to action -->
-      <div class="jumbotron">
-        <div
-          class="container d-flex flex-row align-items-center justify-content-between flex-wrap-reverse"
+      <div class="container-fluid bg-dark text-white p-5" id="jumbotron">
+          <div
+            class="container d-flex flex-row align-items-center justify-content-between flex-wrap-reverse"
         >
           <div>
             <h1 class="display-3">

--- a/static/index.html
+++ b/static/index.html
@@ -21,100 +21,122 @@
 
   <body>
     <nav class="navbar navbar-expand-lg navbar-light bg-light">
-      <a class="navbar-brand" href="index.html">
-        <img
-          src="favicon.svg"
-          alt="elea-logo"
-          width="30rem"
-          height="30rem"
-          class="d-inline-block align-top"
-        />
-        Build Your Own EA
-      </a>
-      <button
-        class="navbar-toggler"
-        type="button"
-        data-toggle="collapse"
-        data-target="#navbarSupportedContent"
-        aria-controls="navbarSupportedContent"
-        aria-expanded="false"
-        aria-label="Toggle navigation"
-      >
-        <span class="navbar-toggler-icon"></span>
-      </button>
-
-      <div class="collapse navbar-collapse" id="navbarSupportedContent">
-        <ul class="navbar-nav mr-auto">
-          <li class="nav-item">
-            <a class="nav-link" href="workspace.html?example=full">
-              Demo
-              <span class="sr-only">(current)</span>
-            </a>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link" href="faq.html">FAQ</a>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link" href="documentation.html">Documentation</a>
-          </li>
-          <li class="nav-item dropdown">
-            <a
-              class="nav-link dropdown-toggle"
-              href="#"
-              id="navbarExampleDropdown"
-              role="button"
-              data-toggle="dropdown"
-              aria-haspopup="true"
-              aria-expanded="false"
+      <div class="container-fluid">
+        <a class="navbar-brand" href="index.html">
+          <img
+            src="favicon.svg"
+            alt="elea-logo"
+            width="30rem"
+            height="30rem"
+            class="d-inline-block align-top"
+          />
+          Build Your Own EA
+        </a>
+        <button 
+            class="navbar-toggler" 
+            type="button" 
+            data-bs-toggle="offcanvas" 
+            data-bs-target="#navbarOffcanvasLg" 
+            aria-controls="navbarOffcanvasLg"
+            aria-expanded="false"
+            aria-label="Toggle navigation"
             >
-              Examples
-            </a>
-            <div class="dropdown-menu" aria-labelledby="navbarExampleDropdown">
-              <a class="dropdown-item" href="workspace.html?example=empty">
-                Empty starting point
-              </a>
-              <div class="dropdown-divider"></div>
-              <a class="dropdown-item" href="workspace.html?example=full">
-                Full example
-              </a>
-              <a class="dropdown-item" href="workspace.html?example=simple">
-                Simple example
-              </a>
-              <div class="dropdown-divider"></div>
-              <a class="dropdown-item" href="workspace.html?example=oneplusone">
-                1+1
-              </a>
-              <a
-                class="dropdown-item"
-                href="workspace.html?example=onepluslambda"
-              >
-                1+λ
-              </a>
-              <a class="dropdown-item" href="workspace.html?example=onelambda">
-                1,λ
-              </a>
-              <div class="dropdown-divider"></div>
-              <a
-                class="dropdown-item"
-                href="workspace.html?example=multithread"
-              >
-                Multi-Threading Example
-              </a>
-              <a
-                class="dropdown-item"
-                href="workspace.html?example=full_multithread"
-              >
-                Full example with Multi-Threading
-              </a>
-              <a
-                class="dropdown-item"
-                href="workspace.html?example=multithread-performance"
-              >
-                Muti-Threading Performance Test
-              </a>
-            </div>
-          </li>
-        </ul>
+          <span class="navbar-toggler-icon"></span>
+        </button>
+  
+        <div class="offcanvas offcanvas-end" tabindex="-1" id="navbarOffcanvasLg" aria-labelledby="navbarOffcanvasLgLabel">
+          <div class="offcanvas-header">
+            <h5 class="offcanvas-title" id="offcanvasNavbarLabel">Build Your Own EA</h5>
+            <button
+              type="button"
+              class="btn-close"
+              data-bs-dismiss="offcanvas"
+              aria-label="Close"
+            ></button>
+          </div>
+          <div class="offcanvas-body">
+            <ul class="navbar-nav mr-auto">
+              <li class="nav-item">
+                <a class="nav-link" href="workspace.html?example=full">
+                  Demo
+                  <span class="sr-only">(current)</span>
+                </a>
+              </li>
+              <li class="nav-item">
+                <a class="nav-link" href="faq.html">FAQ</a>
+              </li>
+              <li class="nav-item">
+                <a class="nav-link" href="documentation.html">Documentation</a>
+              </li>
+              <li class="nav-item dropdown">
+                <a
+                  class="nav-link dropdown-toggle"
+                  href="#"
+                  id="navbarExampleDropdown"
+                  role="button"
+                  data-bs-toggle="dropdown"
+                  aria-haspopup="true"
+                  aria-expanded="false"
+                >
+                  Examples
+                </a>
+                <ul
+                  class="dropdown-menu"
+                  aria-labelledby="navbarExampleDropdown"
+                >
+                  <li><a class="dropdown-item" href="workspace.html?example=empty">
+                    Empty starting point
+                  </a></li>
+                  <li><hr class="dropdown-divider"></li>
+                  <li><a class="dropdown-item" href="workspace.html?example=full">
+                    Full example
+                  </a></li>
+                  <li><a class="dropdown-item" href="workspace.html?example=simple">
+                    Simple example
+                  </a></li>
+                  <li><hr class="dropdown-divider"></li>
+                  <li><a
+                    class="dropdown-item"
+                    href="workspace.html?example=oneplusone"
+                  >
+                    1+1
+                  </a></li>
+                  <li><a
+                    class="dropdown-item"
+                    href="workspace.html?example=onepluslambda"
+                  >
+                    1+λ
+                  </a></li>
+                  <li><a
+                    class="dropdown-item"
+                    href="workspace.html?example=onelambda"
+                  >
+                    1,λ
+                  </a></li>
+                  <li><hr class="dropdown-divider"></li>
+                  <li><a
+                    class="dropdown-item"
+                    href="workspace.html?example=multithread"
+                  >
+                    Multi-Threading Example
+                  </a></li>
+                  <li><a
+                    class="dropdown-item"
+                    href="workspace.html?example=full_multithread"
+                  >
+                    Full example with Multi-Threading
+                  </a></li>
+                  <li><a
+                    class="dropdown-item"
+                    href="workspace.html?example=multithread-performance"
+                  >
+                    Multi-Threading Performance Test
+                  </a></li>
+                </ul>
+              </li>
+            </ul>
+          </div>
+        </div>
       </div>
     </nav>
     <main role="main">

--- a/static/legal.html
+++ b/static/legal.html
@@ -112,7 +112,7 @@
       </div>
     </nav>
     <main>
-      <div class="jumbotron">
+      <div class="container-fluid bg-dark text-white p-5" id="jumbotron">
         <div class="container">
           <h1 class="display-3">Legal Notice</h1>
         </div>

--- a/static/legal.html
+++ b/static/legal.html
@@ -20,95 +20,122 @@
 
   <body>
     <nav class="navbar navbar-expand-lg navbar-light bg-light">
-      <a class="navbar-brand" href="index.html">
-        <img
-          src="favicon.svg"
-          alt="elea-logo"
-          width="30rem"
-          height="30rem"
-          class="d-inline-block align-top"
-        />
-        Build Your Own EA
-      </a>
-      <button
-        class="navbar-toggler"
-        type="button"
-        data-toggle="collapse"
-        data-target="#navbarSupportedContent"
-        aria-controls="navbarSupportedContent"
-        aria-expanded="false"
-        aria-label="Toggle navigation"
-      >
-        <span class="navbar-toggler-icon"></span>
-      </button>
-
-      <div class="collapse navbar-collapse" id="navbarSupportedContent">
-        <ul class="navbar-nav mr-auto">
-          <li class="nav-item">
-            <a class="nav-link" href="workspace.html?example=full">
-              Demo
-              <span class="sr-only">(current)</span>
-            </a>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link" target="_blank" href="faq.html">FAQ</a>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link" target="_blank" href="documentation.html">
-              Documentation
-            </a>
-          </li>
-          <li class="nav-item dropdown">
-            <a
-              class="nav-link dropdown-toggle"
-              href="#"
-              id="navbarExampleDropdown"
-              role="button"
-              data-toggle="dropdown"
-              aria-haspopup="true"
-              aria-expanded="false"
+      <div class="container-fluid">
+        <a class="navbar-brand" href="index.html">
+          <img
+            src="favicon.svg"
+            alt="elea-logo"
+            width="30rem"
+            height="30rem"
+            class="d-inline-block align-top"
+          />
+          Build Your Own EA
+        </a>
+        <button 
+            class="navbar-toggler" 
+            type="button" 
+            data-bs-toggle="offcanvas" 
+            data-bs-target="#navbarOffcanvasLg" 
+            aria-controls="navbarOffcanvasLg"
+            aria-expanded="false"
+            aria-label="Toggle navigation"
             >
-              Examples
-            </a>
-            <div class="dropdown-menu" aria-labelledby="navbarExampleDropdown">
-              <a class="dropdown-item" href="workspace.html?example=empty">
-                Empty starting point
-              </a>
-              <div class="dropdown-divider"></div>
-              <a class="dropdown-item" href="workspace.html?example=fulll">
-                Full example
-              </a>
-              <a class="dropdown-item" href="workspace.html?example=simple">
-                Simple example
-              </a>
-              <div class="dropdown-divider"></div>
-              <a class="dropdown-item" href="workspace.html?example=oneplusone">
-                1+1
-              </a>
-              <a class="dropdown-item" href="#">1+λ (TODO)</a>
-              <a class="dropdown-item" href="#">1,λ (TODO)</a>
-              <div class="dropdown-divider"></div>
-              <a
-                class="dropdown-item"
-                href="workspace.html?example=multithread"
-              >
-                Multi-Threading Example
-              </a>
-              <a
-                class="dropdown-item"
-                href="workspace.html?example=full_multithread"
-              >
-                Full example with Muti-Threading
-              </a>
-              <a
-                class="dropdown-item"
-                href="workspace.html?example=multithread-performance"
-              >
-                Muti-Threading Performance Test
-              </a>
-            </div>
-          </li>
-        </ul>
+          <span class="navbar-toggler-icon"></span>
+        </button>
+  
+        <div class="offcanvas offcanvas-end" tabindex="-1" id="navbarOffcanvasLg" aria-labelledby="navbarOffcanvasLgLabel">
+          <div class="offcanvas-header">
+            <h5 class="offcanvas-title" id="offcanvasNavbarLabel">Build Your Own EA</h5>
+            <button
+              type="button"
+              class="btn-close"
+              data-bs-dismiss="offcanvas"
+              aria-label="Close"
+            ></button>
+          </div>
+          <div class="offcanvas-body">
+            <ul class="navbar-nav mr-auto">
+              <li class="nav-item">
+                <a class="nav-link" href="workspace.html?example=full">
+                  Demo
+                  <span class="sr-only">(current)</span>
+                </a>
+              </li>
+              <li class="nav-item">
+                <a class="nav-link" href="faq.html">FAQ</a>
+              </li>
+              <li class="nav-item">
+                <a class="nav-link" href="documentation.html">Documentation</a>
+              </li>
+              <li class="nav-item dropdown">
+                <a
+                  class="nav-link dropdown-toggle"
+                  href="#"
+                  id="navbarExampleDropdown"
+                  role="button"
+                  data-bs-toggle="dropdown"
+                  aria-haspopup="true"
+                  aria-expanded="false"
+                >
+                  Examples
+                </a>
+                <ul
+                  class="dropdown-menu"
+                  aria-labelledby="navbarExampleDropdown"
+                >
+                  <li><a class="dropdown-item" href="workspace.html?example=empty">
+                    Empty starting point
+                  </a></li>
+                  <li><hr class="dropdown-divider"></li>
+                  <li><a class="dropdown-item" href="workspace.html?example=full">
+                    Full example
+                  </a></li>
+                  <li><a class="dropdown-item" href="workspace.html?example=simple">
+                    Simple example
+                  </a></li>
+                  <li><hr class="dropdown-divider"></li>
+                  <li><a
+                    class="dropdown-item"
+                    href="workspace.html?example=oneplusone"
+                  >
+                    1+1
+                  </a></li>
+                  <li><a
+                    class="dropdown-item"
+                    href="workspace.html?example=onepluslambda"
+                  >
+                    1+λ
+                  </a></li>
+                  <li><a
+                    class="dropdown-item"
+                    href="workspace.html?example=onelambda"
+                  >
+                    1,λ
+                  </a></li>
+                  <li><hr class="dropdown-divider"></li>
+                  <li><a
+                    class="dropdown-item"
+                    href="workspace.html?example=multithread"
+                  >
+                    Multi-Threading Example
+                  </a></li>
+                  <li><a
+                    class="dropdown-item"
+                    href="workspace.html?example=full_multithread"
+                  >
+                    Full example with Multi-Threading
+                  </a></li>
+                  <li><a
+                    class="dropdown-item"
+                    href="workspace.html?example=multithread-performance"
+                  >
+                    Multi-Threading Performance Test
+                  </a></li>
+                </ul>
+              </li>
+            </ul>
+          </div>
+        </div>
       </div>
     </nav>
     <main>

--- a/static/privacy.html
+++ b/static/privacy.html
@@ -112,7 +112,7 @@
       </div>
     </nav>
     <main>
-      <div class="jumbotron">
+      <div class="container-fluid bg-dark text-white p-5" id="jumbotron">
         <div class="container">
           <h1 class="display-3">Privacy Policy</h1>
         </div>

--- a/static/privacy.html
+++ b/static/privacy.html
@@ -20,95 +20,122 @@
 
   <body>
     <nav class="navbar navbar-expand-lg navbar-light bg-light">
-      <a class="navbar-brand" href="index.html">
-        <img
-          src="favicon.svg"
-          alt="elea-logo"
-          width="30rem"
-          height="30rem"
-          class="d-inline-block align-top"
-        />
-        Build Your Own EA
-      </a>
-      <button
-        class="navbar-toggler"
-        type="button"
-        data-toggle="collapse"
-        data-target="#navbarSupportedContent"
-        aria-controls="navbarSupportedContent"
-        aria-expanded="false"
-        aria-label="Toggle navigation"
-      >
-        <span class="navbar-toggler-icon"></span>
-      </button>
-
-      <div class="collapse navbar-collapse" id="navbarSupportedContent">
-        <ul class="navbar-nav mr-auto">
-          <li class="nav-item">
-            <a class="nav-link" href="workspace.html?example=full">
-              Demo
-              <span class="sr-only">(current)</span>
-            </a>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link" target="_blank" href="faq.html">FAQ</a>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link" target="_blank" href="documentation.html">
-              Documentation
-            </a>
-          </li>
-          <li class="nav-item dropdown">
-            <a
-              class="nav-link dropdown-toggle"
-              href="#"
-              id="navbarExampleDropdown"
-              role="button"
-              data-toggle="dropdown"
-              aria-haspopup="true"
-              aria-expanded="false"
+      <div class="container-fluid">
+        <a class="navbar-brand" href="index.html">
+          <img
+            src="favicon.svg"
+            alt="elea-logo"
+            width="30rem"
+            height="30rem"
+            class="d-inline-block align-top"
+          />
+          Build Your Own EA
+        </a>
+        <button 
+            class="navbar-toggler" 
+            type="button" 
+            data-bs-toggle="offcanvas" 
+            data-bs-target="#navbarOffcanvasLg" 
+            aria-controls="navbarOffcanvasLg"
+            aria-expanded="false"
+            aria-label="Toggle navigation"
             >
-              Examples
-            </a>
-            <div class="dropdown-menu" aria-labelledby="navbarExampleDropdown">
-              <a class="dropdown-item" href="workspace.html?example=empty">
-                Empty starting point
-              </a>
-              <div class="dropdown-divider"></div>
-              <a class="dropdown-item" href="workspace.html?example=fulll">
-                Full example
-              </a>
-              <a class="dropdown-item" href="workspace.html?example=simple">
-                Simple example
-              </a>
-              <div class="dropdown-divider"></div>
-              <a class="dropdown-item" href="workspace.html?example=oneplusone">
-                1+1
-              </a>
-              <a class="dropdown-item" href="#">1+λ (TODO)</a>
-              <a class="dropdown-item" href="#">1,λ (TODO)</a>
-              <div class="dropdown-divider"></div>
-              <a
-                class="dropdown-item"
-                href="workspace.html?example=multithread"
-              >
-                Multi-Threading Example
-              </a>
-              <a
-                class="dropdown-item"
-                href="workspace.html?example=full_multithread"
-              >
-                Full example with Muti-Threading
-              </a>
-              <a
-                class="dropdown-item"
-                href="workspace.html?example=multithread-performance"
-              >
-                Muti-Threading Performance Test
-              </a>
-            </div>
-          </li>
-        </ul>
+          <span class="navbar-toggler-icon"></span>
+        </button>
+  
+        <div class="offcanvas offcanvas-end" tabindex="-1" id="navbarOffcanvasLg" aria-labelledby="navbarOffcanvasLgLabel">
+          <div class="offcanvas-header">
+            <h5 class="offcanvas-title" id="offcanvasNavbarLabel">Build Your Own EA</h5>
+            <button
+              type="button"
+              class="btn-close"
+              data-bs-dismiss="offcanvas"
+              aria-label="Close"
+            ></button>
+          </div>
+          <div class="offcanvas-body">
+            <ul class="navbar-nav mr-auto">
+              <li class="nav-item">
+                <a class="nav-link" href="workspace.html?example=full">
+                  Demo
+                  <span class="sr-only">(current)</span>
+                </a>
+              </li>
+              <li class="nav-item">
+                <a class="nav-link" href="faq.html">FAQ</a>
+              </li>
+              <li class="nav-item">
+                <a class="nav-link" href="documentation.html">Documentation</a>
+              </li>
+              <li class="nav-item dropdown">
+                <a
+                  class="nav-link dropdown-toggle"
+                  href="#"
+                  id="navbarExampleDropdown"
+                  role="button"
+                  data-bs-toggle="dropdown"
+                  aria-haspopup="true"
+                  aria-expanded="false"
+                >
+                  Examples
+                </a>
+                <ul
+                  class="dropdown-menu"
+                  aria-labelledby="navbarExampleDropdown"
+                >
+                  <li><a class="dropdown-item" href="workspace.html?example=empty">
+                    Empty starting point
+                  </a></li>
+                  <li><hr class="dropdown-divider"></li>
+                  <li><a class="dropdown-item" href="workspace.html?example=full">
+                    Full example
+                  </a></li>
+                  <li><a class="dropdown-item" href="workspace.html?example=simple">
+                    Simple example
+                  </a></li>
+                  <li><hr class="dropdown-divider"></li>
+                  <li><a
+                    class="dropdown-item"
+                    href="workspace.html?example=oneplusone"
+                  >
+                    1+1
+                  </a></li>
+                  <li><a
+                    class="dropdown-item"
+                    href="workspace.html?example=onepluslambda"
+                  >
+                    1+λ
+                  </a></li>
+                  <li><a
+                    class="dropdown-item"
+                    href="workspace.html?example=onelambda"
+                  >
+                    1,λ
+                  </a></li>
+                  <li><hr class="dropdown-divider"></li>
+                  <li><a
+                    class="dropdown-item"
+                    href="workspace.html?example=multithread"
+                  >
+                    Multi-Threading Example
+                  </a></li>
+                  <li><a
+                    class="dropdown-item"
+                    href="workspace.html?example=full_multithread"
+                  >
+                    Full example with Multi-Threading
+                  </a></li>
+                  <li><a
+                    class="dropdown-item"
+                    href="workspace.html?example=multithread-performance"
+                  >
+                    Multi-Threading Performance Test
+                  </a></li>
+                </ul>
+              </li>
+            </ul>
+          </div>
+        </div>
       </div>
     </nav>
     <main>

--- a/static/workspace.html
+++ b/static/workspace.html
@@ -23,139 +23,171 @@
   </head>
 
   <body>
-    <nav class="navbar fixed-top navbar-expand-lg navbar-light bg-light">
-      <a class="navbar-brand" href="index.html">
-        <img
-          src="favicon.svg"
-          alt="elea-logo"
-          width="30rem"
-          height="30rem"
-          class="d-inline-block align-top"
-        />
-        Build Your Own EA
-      </a>
-      <button
-        class="navbar-toggler"
-        type="button"
-        data-toggle="collapse"
-        data-target="#navbarSupportedContent"
-        aria-controls="navbarSupportedContent"
-        aria-expanded="false"
-        aria-label="Toggle navigation"
-      >
-        <span class="navbar-toggler-icon"></span>
-      </button>
-
-      <div class="collapse navbar-collapse" id="navbarSupportedContent">
-        <ul class="navbar-nav mr-auto">
-          <li class="nav-item active">
-            <a class="nav-link active" href="#" id="example-demo">
-              Demo
-              <span class="sr-only">(current)</span>
-            </a>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link" target="_blank" href="faq.html">FAQ</a>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link" target="_blank" href="documentation.html">
-              Documentation
-            </a>
-          </li>
-          <li class="nav-item dropdown">
-            <a
-              class="nav-link dropdown-toggle"
-              href="#"
-              id="navbarExampleDropdown"
-              role="button"
-              data-toggle="dropdown"
-              aria-haspopup="true"
-              aria-expanded="false"
+    <nav class="navbar navbar-expand-lg navbar-light bg-light">
+      <div class="container-fluid">
+        <a class="navbar-brand" href="index.html">
+          <img
+            src="favicon.svg"
+            alt="elea-logo"
+            width="30rem"
+            height="30rem"
+            class="d-inline-block align-top"
+          />
+          Build Your Own EA
+        </a>
+        <button 
+            class="navbar-toggler" 
+            type="button" 
+            data-bs-toggle="offcanvas" 
+            data-bs-target="#navbarOffcanvasLg" 
+            aria-controls="navbarOffcanvasLg"
+            aria-expanded="false"
+            aria-label="Toggle navigation"
             >
-              Examples
-            </a>
-            <div class="dropdown-menu" aria-labelledby="navbarExampleDropdown">
-              <a class="dropdown-item" id="example-empty">
-                Empty starting point
-              </a>
-              <div class="dropdown-divider"></div>
-              <a class="dropdown-item" id="example-full">Full example</a>
-              <a class="dropdown-item" id="example-simple">Simple example</a>
-              <div class="dropdown-divider"></div>
-              <a class="dropdown-item" id="example-oneplusone">1+1</a>
-              <a class="dropdown-item" id="example-onepluslambda" href="#">
-                1+λ
-              </a>
-              <a class="dropdown-item" id="example-onelambda">1,λ</a>
-              <div class="dropdown-divider"></div>
-              <a class="dropdown-item" id="example-multithread">
-                Multi-Threading Example
-              </a>
-              <a class="dropdown-item" id="example-full-multithread">
-                Full Example with Multi-Threading
-              </a>
-              <a class="dropdown-item" id="example-multithread-performance">
-                Multi-Threading Performance Test
-              </a>
-              <div class="dropdown-divider"></div>
-              <a class="dropdown-item" id="example-simple-plotting">
-                Simple Plotting example
-              </a>
-            </div>
-          </li>
-          <li class="nav-item dropdown">
-            <a
-              class="nav-link dropdown-toggle"
-              href="#"
-              id="navbarSaveDropdown"
-              role="button"
-              data-toggle="dropdown"
-              aria-haspopup="true"
-              aria-expanded="false"
-            >
-              Save/Restore Algorithm
-            </a>
-            <input type="file" id="upload_xml_input" style="display: none" />
-            <div class="dropdown-menu" aria-labelledby="navbarSaveDropdown">
-              <a class="dropdown-item" id="upload_xml" href="#">
-                Upload XML file
-              </a>
-              <a class="dropdown-item" id="promt_for_xml" href="#">
-                Paste XML string
-              </a>
-              <div class="dropdown-divider"></div>
-              <a class="dropdown-item" id="download_xml" href="#">
-                Download XML file
-              </a>
-              <a class="dropdown-item" id="copy_xml" href="#">
-                Copy XML string
-              </a>
-              <div class="dropdown-divider"></div>
-              <a class="dropdown-item" id="download_js" href="#">
-                Download JS project
-              </a>
-              <a
-                class="dropdown-item"
-                data-toggle="modal"
-                id="show_js"
-                href="#jsModal"
-              >
-                Show JS
-              </a>
-              <div class="dropdown-divider"></div>
-              <a class="dropdown-item" id="download_json" href="#jsModal">
-                Download data for IOHanalyzer
-              </a>
-              <a class="dropdown-item" id="download_csv" href="#">
-                Download CSV
-              </a>
-              <a class="dropdown-item" id="download_plots_as_csv" href="#">
-                Download Plots as CSV
-              </a>
-            </div>
-          </li>
-        </ul>
-      </div>
+          <span class="navbar-toggler-icon"></span>
+        </button>
+  
+        <div class="offcanvas offcanvas-end" tabindex="-1" id="navbarOffcanvasLg" aria-labelledby="navbarOffcanvasLgLabel">
+          <div class="offcanvas-header">
+            <h5 class="offcanvas-title" id="offcanvasNavbarLabel">Build Your Own EA</h5>
+            <button
+              type="button"
+              class="btn-close"
+              data-bs-dismiss="offcanvas"
+              aria-label="Close"
+            ></button>
+          </div>
+          <div class="offcanvas-body">
+            <ul class="navbar-nav mr-auto">
+              <li class="nav-item">
+                <a class="nav-link" href="workspace.html?example=full">
+                  Demo
+                  <span class="sr-only">(current)</span>
+                </a>
+              </li>
+              <li class="nav-item">
+                <a class="nav-link" href="faq.html">FAQ</a>
+              </li>
+              <li class="nav-item">
+                <a class="nav-link" href="documentation.html">Documentation</a>
+              </li>
+              <li class="nav-item dropdown">
+                <a
+                  class="nav-link dropdown-toggle"
+                  href="#"
+                  id="navbarExampleDropdown"
+                  role="button"
+                  data-bs-toggle="dropdown"
+                  aria-haspopup="true"
+                  aria-expanded="false"
+                >
+                  Examples
+                </a>
+                <ul
+                  class="dropdown-menu"
+                  aria-labelledby="navbarExampleDropdown"
+                >
+                  <li><a class="dropdown-item" href="workspace.html?example=empty">
+                    Empty starting point
+                  </a></li>
+                  <li><hr class="dropdown-divider"></li>
+                  <li><a class="dropdown-item" href="workspace.html?example=full">
+                    Full example
+                  </a></li>
+                  <li><a class="dropdown-item" href="workspace.html?example=simple">
+                    Simple example
+                  </a></li>
+                  <li><hr class="dropdown-divider"></li>
+                  <li><a
+                    class="dropdown-item"
+                    href="workspace.html?example=oneplusone"
+                  >
+                    1+1
+                  </a></li>
+                  <li><a
+                    class="dropdown-item"
+                    href="workspace.html?example=onepluslambda"
+                  >
+                    1+λ
+                  </a></li>
+                  <li><a
+                    class="dropdown-item"
+                    href="workspace.html?example=onelambda"
+                  >
+                    1,λ
+                  </a></li>
+                  <li><hr class="dropdown-divider"></li>
+                  <li><a
+                    class="dropdown-item"
+                    href="workspace.html?example=multithread"
+                  >
+                    Multi-Threading Example
+                  </a></li>
+                  <li><a
+                    class="dropdown-item"
+                    href="workspace.html?example=full_multithread"
+                  >
+                    Full example with Multi-Threading
+                  </a></li>
+                  <li><a
+                    class="dropdown-item"
+                    href="workspace.html?example=multithread-performance"
+                  >
+                    Multi-Threading Performance Test
+                  </a></li>
+                </ul>
+              </li>
+              <li class="nav-item dropdown">
+                <a
+                  class="nav-link dropdown-toggle"
+                  href="#"
+                  id="navbarSaveDropdown"
+                  role="button"
+                  data-bs-toggle="dropdown"
+                  aria-haspopup="true"
+                  aria-expanded="false"
+                >
+                  Save/Restore Algorithm
+                </a>
+                <input type="file" id="upload_xml_input" style="display: none" />
+                <ul class="dropdown-menu" aria-labelledby="navbarSaveDropdown">
+                  <li><a class="dropdown-item" id="upload_xml" href="#">
+                    Upload XML file
+                  </a></li>
+                  <li><a class="dropdown-item" id="promt_for_xml" href="#">
+                    Paste XML string
+                  </a></li>
+                  <li><hr class="dropdown-divider"></li>
+                  <li><a class="dropdown-item" id="download_xml" href="#">
+                    Download XML file
+                  </a></li>
+                  <li><a class="dropdown-item" id="copy_xml" href="#">
+                    Copy XML string
+                  </a></li>
+                  <li><hr class="dropdown-divider"></li>
+                  <li><a class="dropdown-item" id="download_js" href="#">
+                    Download JS project
+                  </a></li>
+                  <li><a
+                    class="dropdown-item"
+                    data-bs-toggle="modal"
+                    id="show_js"
+                    data-bs-target="#jsModal"
+                  >
+                    Show JS
+                  </a></li>
+                  <li><hr class="dropdown-divider"></li>
+                  <li><a class="dropdown-item" id="download_json" href="#jsModal">
+                    Download data for IOHanalyzer
+                  </a></li>
+                  <li><a class="dropdown-item" id="download_csv" href="#">
+                    Download CSV
+                  </a></li>
+                </ul>
+              </li>
+            </ul>
+          </div>
+        </div>
     </nav>
     <main>
       <div id="spinner">

--- a/static/workspace.html
+++ b/static/workspace.html
@@ -97,6 +97,10 @@
               <a class="dropdown-item" id="example-multithread-performance">
                 Multi-Threading Performance Test
               </a>
+              <div class="dropdown-divider"></div>
+              <a class="dropdown-item" id="example-simple-plotting">
+                Simple Plotting example
+              </a>
             </div>
           </li>
           <li class="nav-item dropdown">
@@ -145,6 +149,9 @@
               <a class="dropdown-item" id="download_csv" href="#">
                 Download CSV
               </a>
+              <a class="dropdown-item" id="download_plots_as_csv" href="#">
+                Download Plots as CSV
+              </a>
             </div>
           </li>
         </ul>
@@ -161,9 +168,7 @@
           <div class="modal-content">
             <div class="modal-header">
               <h5 class="modal-title">Javascript Code</h5>
-              <button type="button" class="close" data-dismiss="modal">
-                ×
-              </button>
+              <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
             </div>
             <div class="modal-body">
               <pre>
@@ -203,8 +208,8 @@
             type="button"
             class="btn btn-outline-dark btn-block"
             id="show-button"
-            data-toggle="modal"
-            href="#jsModal"
+            data-bs-toggle="modal"
+            data-bs-target="#jsModal"
           >
             Show Code
           </button>
@@ -220,7 +225,7 @@
           <!-- <button type="button" class="btn btn-outline-dark btn-block" id="reset-button">Reset execution</button> -->
         </div>
       </div>
-      <div id="workspace-content" style="opacity: 0">
+      <div class="container-fluid" id="workspace-content" style="opacity: 0">
         <div id="blockly-area"></div>
         <div id="blockly-div" style="position: absolute"></div>
         <div id="output-column"></div>


### PR DESCRIPTION
implemented the bootstrap offcanvas on all pages to fix layout issues, when not in a full-screen tab. to do this bootstrap needed to be updated to version 5.2. the first two commits migrate bootstrap to version 5.2 and fix minor issues resulting from the migration. the third commit then implements the offcanvas. additionally the color of the jumbotron on index, legal, documentation and faq pages had to be changed due to the bootstrap update.

ps: accidently created this branch of of add_threadblock_tooltips_and_rework_naming branch. pls only merge this PR after merging PR #167.