### PR TITLE
remove mousewheel zoom, add mousewheel scroll

### DIFF
--- a/static/scripts/modules/blocklyHandling.js
+++ b/static/scripts/modules/blocklyHandling.js
@@ -38,7 +38,7 @@ var workspace = Blockly.inject(blocklyDiv, {
   toolbox: document.getElementById("toolbox"),
   zoom: {
     controls: true,
-    wheel: true,
+    wheel: false,
     startScale: 1.0,
     maxScale: 2.5,
     minScale: 0.4,
@@ -47,6 +47,9 @@ var workspace = Blockly.inject(blocklyDiv, {
   },
   trashcan: true,
   theme: theme,
+  move: {
+    wheel: true,
+  },
 });
 Blockly.Xml.domToWorkspace(document.getElementById("startBlocks"), workspace);
 var onresize = function () {


### PR DESCRIPTION
I removed the annoying mousewheel zoom but left zooming in general in for now. The mousewheel now scrolls up and down in the workspace. However it doesn't feel good either, so I think we will need some feedback on this. 