### PR TITLE
Toolbox overhaul

### DIFF
--- a/static/blockDefinition/normalBlocks.js
+++ b/static/blockDefinition/normalBlocks.js
@@ -327,7 +327,7 @@ export const blockDefinitions = [
     ],
     previousStatement: null,
     nextStatement: null,
-    style: "pop_blocks",
+    style: "indiv_blocks",
     tooltip: "Adds an individual to a population.",
     helpUrl: "",
   },
@@ -377,7 +377,7 @@ export const blockDefinitions = [
       },
     ],
     output: "Individual",
-    style: "pop_blocks",
+    style: "indiv_blocks",
     tooltip:
       "Selects an individual from a population based on given selection strategy.",
     helpUrl: "",
@@ -573,7 +573,7 @@ export const blockDefinitions = [
     ],
     inputsInline: false,
     output: "Individual",
-    style: "pop_blocks",
+    style: "indiv_blocks",
     tooltip:
       "Selects the best individuals from a population using the given 'fitness'-function.",
     helpUrl: "",

--- a/static/workspace.html
+++ b/static/workspace.html
@@ -342,15 +342,12 @@
             </block>
           </value>
         </block>
-        <block type="ea_select_parent"></block>
-        <block type="ea_select_best"></block>
         <block type="check_fitness"></block>
 
         <label text="Manipulation"></label>
         <block type="ea_addtopopulation"></block>
         <block type="lists_sort"></block>
         <block type="lists_concat"></block>
-        <block type="lists_append"></block>
         <block type="lists_setIndex">
           <value name="LIST">
             <block type="variables_get_population">
@@ -380,6 +377,9 @@
         <block type="individual_init_constant"></block>
 
         <label text="Queries"></label>
+        <block type="lists_append"></block>
+        <block type="ea_select_best"></block>
+        <block type="ea_select_parent"></block>
 
         <label text="Manipulation"></label>
         <block type="ea_copy"></block>


### PR DESCRIPTION
changed categories for some blocks. list blocks remain the same, because they are default blockly blocks.