### PR TITLE
remove github links for paper review

### DIFF
--- a/static/documentation.html
+++ b/static/documentation.html
@@ -330,8 +330,6 @@
         <a href="https://developers.google.com/blockly">Blockly</a>
       </p>
       <p>
-        <a href="https://github.com/HPI-ELEA/elea">Github</a>
-        •
         <a href="/legal.html">Legal</a>
         •
         <a href="/privacy.html">Privacy</a>

--- a/static/faq.html
+++ b/static/faq.html
@@ -200,8 +200,6 @@
         <a href="https://developers.google.com/blockly">Blockly</a>
       </p>
       <p>
-        <a href="https://github.com/HPI-ELEA/elea">Github</a>
-        •
         <a href="/legal.html">Legal</a>
         •
         <a href="/privacy.html">Privacy</a>

--- a/static/index.html
+++ b/static/index.html
@@ -229,8 +229,6 @@
         <a href="https://developers.google.com/blockly">Blockly</a>
       </p>
       <p>
-        <a href="https://github.com/HPI-ELEA/elea">Github</a>
-        •
         <a href="/legal.html">Legal</a>
         •
         <a href="/privacy.html">Privacy</a>

--- a/static/legal.html
+++ b/static/legal.html
@@ -177,8 +177,6 @@
         <a href="https://developers.google.com/blockly">Blockly</a>
       </p>
       <p>
-        <a href="https://github.com/HPI-ELEA/elea">Github</a>
-        •
         <a href="/legal.html">Legal</a>
         •
         <a href="/privacy.html">Privacy</a>

--- a/static/privacy.html
+++ b/static/privacy.html
@@ -568,8 +568,6 @@
         <a href="https://developers.google.com/blockly">Blockly</a>
       </p>
       <p>
-        <a href="https://github.com/HPI-ELEA/elea">Github</a>
-        •
         <a href="/legal.html">Legal</a>
         •
         <a href="/privacy.html">Privacy</a>

--- a/static/workspace.html
+++ b/static/workspace.html
@@ -409,8 +409,6 @@
         <a href="https://developers.google.com/blockly">Blockly</a>
       </p>
       <p>
-        <a href="https://github.com/HPI-ELEA/elea">Github</a>
-        •
         <a href="/legal.html">Legal</a>
         •
         <a href="/privacy.html">Privacy</a>


### PR DESCRIPTION
Not sure if we said that this was necessary or what else we needed to remove.