### PR TITLE
make carousel buttons more readable

### DIFF
--- a/static/css/workspace.css
+++ b/static/css/workspace.css
@@ -108,6 +108,29 @@ main {
   padding: 1rem;
 }
 
+.carousel-control-next, .carousel-control-prev {
+  width: 50px;
+  height: 50px;
+  background-color: rgb(230, 100, 48);
+  border-radius: 50%;
+  top: calc(50% - 25px);
+  opacity: .8;
+}
+
+.carousel-control-next {
+  right: 5%;
+}
+
+.carousel-control-next-icon {
+  margin-top: 4px;
+  margin-left: 4px;
+}
+
+.carousel-control-prev-icon {
+  margin-top: 4px;
+  margin-right: 4px;
+}
+
 #cookieBannerDialog {
   position: absolute;
   right: 25px;

--- a/static/css/workspace.css
+++ b/static/css/workspace.css
@@ -103,18 +103,19 @@ main {
 }
 
 .carousel-caption {
-  background-color: rgba(255,255,255,0.8);
+  background-color: rgba(255, 255, 255, 0.8);
   border-radius: 7px;
   padding: 1rem;
 }
 
-.carousel-control-next, .carousel-control-prev {
+.carousel-control-next,
+.carousel-control-prev {
   width: 50px;
   height: 50px;
-  background-color: rgb(230, 100, 48);
+  background-color: #d47404;
   border-radius: 50%;
   top: calc(50% - 25px);
-  opacity: .8;
+  opacity: 0.8;
 }
 
 .carousel-control-next {

--- a/static/workspace.html
+++ b/static/workspace.html
@@ -224,7 +224,7 @@
               <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close" id="tutorialModalClose"></button>
             </div>
             <div class="modal-body">
-              <div id="tutorialCarousel" class="carousel carousel-fade carousel-dark slide" data-bs-interval="false" data-bs-wrap="false">
+              <div id="tutorialCarousel" class="carousel carousel-fade carousel-dark slide" data-bs-interval="false" data-bs-wrap="false" keyboard="true">
                 <div class="carousel-indicators">
                   <button type="button" data-bs-target="#carouselExampleIndicators" data-bs-slide-to="0" class="active" aria-current="true" aria-label="Slide 1"></button>
                   <button type="button" data-bs-target="#carouselExampleIndicators" data-bs-slide-to="1" aria-label="Slide 2"></button>


### PR DESCRIPTION
I put a colorful circle behind the carousel buttons of the tutorial to make improve their visibility. The carousel can now also be navigated via the keyboard.