### PR TITLE
disable tooltips for plots

### DIFF
--- a/static/scripts/PlotHandler.js
+++ b/static/scripts/PlotHandler.js
@@ -149,6 +149,7 @@ class PlotWorker {
               beginAtZero: false,
             },
           },
+          responsive: true,
           plugins: {
             title: {
               display: true,
@@ -158,6 +159,9 @@ class PlotWorker {
               position: "top",
               maxHeight: 30,
               textDirection: "ltr",
+            },
+            tooltip: {
+              enabled: false,
             },
           },
         },


### PR DESCRIPTION
Disable tooltips to improve performance and don't show all datapoints when hovering over a plot.